### PR TITLE
Backporting facebook binding sources

### DIFF
--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdChoicesView.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdChoicesView.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
+import org.robovm.apple.foundation.NSURL;
 import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,15 +37,15 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBAdChoicesView() {}
-    protected FBAdChoicesView(Handle h, long handle) { super(h, handle); }
+    protected FBAdChoicesView(long handle) { super(handle); }
     protected FBAdChoicesView(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithNativeAd:")
+
     public FBAdChoicesView(FBNativeAd nativeAd) { super((SkipInit) null); initObject(init(nativeAd)); }
-    @Method(selector = "initWithNativeAd:expandable:")
+
     public FBAdChoicesView(FBNativeAd nativeAd, boolean expandable) { super((SkipInit) null); initObject(init(nativeAd, expandable)); }
-    @Method(selector = "initWithViewController:adChoicesIcon:adChoicesLinkURL:attributes:")
+
     public FBAdChoicesView(UIViewController viewController, FBAdImage adChoicesIcon, NSURL adChoicesLinkURL, FBNativeAdViewAttributes attributes) { super((SkipInit) null); initObject(init(viewController, adChoicesIcon, adChoicesLinkURL, attributes)); }
-    @Method(selector = "initWithViewController:adChoicesIcon:adChoicesLinkURL:attributes:expandable:")
+
     public FBAdChoicesView(UIViewController viewController, FBAdImage adChoicesIcon, NSURL adChoicesLinkURL, FBNativeAdViewAttributes attributes, boolean expandable) { super((SkipInit) null); initObject(init(viewController, adChoicesIcon, adChoicesLinkURL, attributes, expandable)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdCustomSize.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdCustomSize.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
+import org.robovm.apple.coregraphics.CGSize;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +37,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBAdCustomSize() {}
-    protected FBAdCustomSize(Handle h, long handle) { super(h, handle); }
+    protected FBAdCustomSize(long handle) { super(handle); }
     protected FBAdCustomSize(SkipInit skipInit) { super(skipInit); }
-    public FBAdCustomSize(@ByVal CGSize size) { super((Handle) null, create(size)); retain(getHandle()); }
+    public FBAdCustomSize(@ByVal CGSize size) { super(create(size)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdImage.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdImage.java
@@ -15,21 +15,14 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSURL;
+import org.robovm.apple.uikit.UIImage;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
+import org.robovm.objc.block.VoidBlock1;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +38,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBAdImage() {}
-    protected FBAdImage(Handle h, long handle) { super(h, handle); }
+    protected FBAdImage(long handle) { super(handle); }
     protected FBAdImage(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithURL:width:height:")
+  
     public FBAdImage(NSURL url, @MachineSizedSInt long width, @MachineSizedSInt long height) { super((SkipInit) null); initObject(init(url, width, height)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdSettings.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdSettings.java
@@ -15,21 +15,15 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import java.util.List;
+
+import org.robovm.apple.foundation.NSArray;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +39,7 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBAdSettings() {}
-    protected FBAdSettings(Handle h, long handle) { super(h, handle); }
+    protected FBAdSettings(long handle) { super(handle); }
     protected FBAdSettings(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdStarRatingView.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdStarRatingView.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.coregraphics.CGRect;
+import org.robovm.apple.uikit.UIColor;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +37,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBAdStarRatingView() {}
-    protected FBAdStarRatingView(Handle h, long handle) { super(h, handle); }
+    protected FBAdStarRatingView(long handle) { super(handle); }
     protected FBAdStarRatingView(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithFrame:withStarRating:")
+
     public FBAdStarRatingView(@ByVal CGRect frame, @ByVal FBAdStarRating starRating) { super((SkipInit) null); initObject(init(frame, starRating)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdView.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBAdView.java
@@ -15,21 +15,12 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +36,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBAdView() {}
-    protected FBAdView(Handle h, long handle) { super(h, handle); }
+    protected FBAdView(long handle) { super(handle); }
     protected FBAdView(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithPlacementID:adSize:rootViewController:")
+
     public FBAdView(String placementID, @ByVal FBAdSize adSize, UIViewController viewController) { super((SkipInit) null); initObject(init(placementID, adSize, viewController)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBInterstitialAd.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBInterstitialAd.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSError;
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +37,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBInterstitialAd() {}
-    protected FBInterstitialAd(Handle h, long handle) { super(h, handle); }
+    protected FBInterstitialAd(long handle) { super(handle); }
     protected FBInterstitialAd(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithPlacementID:")
+
     public FBInterstitialAd(String placementID) { super((SkipInit) null); initObject(init(placementID)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBMediaView.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBMediaView.java
@@ -15,21 +15,12 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +36,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBMediaView() {}
-    protected FBMediaView(Handle h, long handle) { super(h, handle); }
+    protected FBMediaView(long handle) { super(handle); }
     protected FBMediaView(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithNativeAd:")
+
     public FBMediaView(FBNativeAd nativeAd) { super((SkipInit) null); initObject(init(nativeAd)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAd.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAd.java
@@ -15,22 +15,14 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSArray;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-/*</imports>*/
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,9 +37,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBNativeAd() {}
-    protected FBNativeAd(Handle h, long handle) { super(h, handle); }
+    protected FBNativeAd(long handle) { super(handle); }
     protected FBNativeAd(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithPlacementID:")
+
     public FBNativeAd(String placementID) { super((SkipInit) null); initObject(init(placementID)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdScrollView.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdScrollView.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
+import org.robovm.objc.block.Block2;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,17 +37,17 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBNativeAdScrollView() {}
-    protected FBNativeAdScrollView(Handle h, long handle) { super(h, handle); }
+    protected FBNativeAdScrollView(long handle) { super(handle); }
     protected FBNativeAdScrollView(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithNativeAdsManager:withType:")
+
     public FBNativeAdScrollView(FBNativeAdsManager manager, FBNativeAdViewType type) { super((SkipInit) null); initObject(init(manager, type)); }
-    @Method(selector = "initWithNativeAdsManager:withType:withAttributes:")
+
     public FBNativeAdScrollView(FBNativeAdsManager manager, FBNativeAdViewType type, FBNativeAdViewAttributes attributes) { super((SkipInit) null); initObject(init(manager, type, attributes)); }
-    @Method(selector = "initWithNativeAdsManager:withType:withAttributes:withMaximum:")
+
     public FBNativeAdScrollView(FBNativeAdsManager manager, FBNativeAdViewType type, FBNativeAdViewAttributes attributes, @MachineSizedUInt long maximumNativeAdCount) { super((SkipInit) null); initObject(init(manager, type, attributes, maximumNativeAdCount)); }
-    @Method(selector = "initWithNativeAdsManager:withViewProvider:")
+
     public FBNativeAdScrollView(FBNativeAdsManager manager, @Block("(,@MachineSizedUInt)") Block2<FBNativeAd, Long, UIView> childViewProvider) { super((SkipInit) null); initObject(init(manager, childViewProvider)); }
-    @Method(selector = "initWithNativeAdsManager:withViewProvider:withMaximum:")
+
     public FBNativeAdScrollView(FBNativeAdsManager manager, @Block("(,@MachineSizedUInt)") Block2<FBNativeAd, Long, UIView> childViewProvider, @MachineSizedUInt long maximumNativeAdCount) { super((SkipInit) null); initObject(init(manager, childViewProvider, maximumNativeAdCount)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdTableViewAdProvider.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdTableViewAdProvider.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSIndexPath;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.uikit.UITableView;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +37,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBNativeAdTableViewAdProvider() {}
-    protected FBNativeAdTableViewAdProvider(Handle h, long handle) { super(h, handle); }
+    protected FBNativeAdTableViewAdProvider(long handle) { super(handle); }
     protected FBNativeAdTableViewAdProvider(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithManager:")
+
     public FBNativeAdTableViewAdProvider(FBNativeAdsManager manager) { super((SkipInit) null); initObject(init(manager)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdTableViewCellProvider.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdTableViewCellProvider.java
@@ -15,21 +15,14 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
+import org.robovm.apple.foundation.NSIndexPath;
+import org.robovm.apple.uikit.UITableView;
+import org.robovm.apple.uikit.UITableViewCell;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,11 +38,11 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBNativeAdTableViewCellProvider() {}
-    protected FBNativeAdTableViewCellProvider(Handle h, long handle) { super(h, handle); }
+    protected FBNativeAdTableViewCellProvider(long handle) { super(handle); }
     protected FBNativeAdTableViewCellProvider(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithManager:forType:")
+
     public FBNativeAdTableViewCellProvider(FBNativeAdsManager manager, FBNativeAdViewType type) { super((SkipInit) null); initObject(init(manager, type)); }
-    @Method(selector = "initWithManager:forType:forAttributes:")
+
     public FBNativeAdTableViewCellProvider(FBNativeAdsManager manager, FBNativeAdViewType type, FBNativeAdViewAttributes attributes) { super((SkipInit) null); initObject(init(manager, type, attributes)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdView.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdView.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,10 +37,10 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBNativeAdView() {}
-    protected FBNativeAdView(Handle h, long handle) { super(h, handle); }
+    protected FBNativeAdView(long handle) { super(handle); }
     protected FBNativeAdView(SkipInit skipInit) { super(skipInit); }
-    public FBNativeAdView(FBNativeAd nativeAd, FBNativeAdViewType type) { super((Handle) null, create(nativeAd, type)); retain(getHandle()); }
-    public FBNativeAdView(FBNativeAd nativeAd, FBNativeAdViewType type, FBNativeAdViewAttributes attributes) { super((Handle) null, create(nativeAd, type, attributes)); retain(getHandle()); }
+    public FBNativeAdView(FBNativeAd nativeAd, FBNativeAdViewType type) { super(create(nativeAd, type)); retain(getHandle()); }
+    public FBNativeAdView(FBNativeAd nativeAd, FBNativeAdViewType type, FBNativeAdViewAttributes attributes) { super(create(nativeAd, type, attributes)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "type")

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdViewAttributes.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdViewAttributes.java
@@ -15,21 +15,15 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSDictionary;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.uikit.UIColor;
+import org.robovm.apple.uikit.UIFont;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +39,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBNativeAdViewAttributes() {}
-    protected FBNativeAdViewAttributes(Handle h, long handle) { super(h, handle); }
+    protected FBNativeAdViewAttributes(long handle) { super(handle); }
     protected FBNativeAdViewAttributes(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithDictionary:")
+
     public FBNativeAdViewAttributes(NSDictionary<?, ?> dict) { super((SkipInit) null); initObject(init(dict)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdsManager.java
+++ b/facebook/ios-audience/src/main/java/org/robovm/pods/facebook/audience/FBNativeAdsManager.java
@@ -15,22 +15,11 @@
  */
 package org.robovm.pods.facebook.audience;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-/*</imports>*/
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,9 +34,9 @@ import org.robovm.apple.coregraphics.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBNativeAdsManager() {}
-    protected FBNativeAdsManager(Handle h, long handle) { super(h, handle); }
+    protected FBNativeAdsManager(long handle) { super(handle); }
     protected FBNativeAdsManager(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithPlacementID:forNumAdsRequested:")
+
     public FBNativeAdsManager(String placementID, @MachineSizedUInt long numAdsRequested) { super((SkipInit) null); initObject(init(placementID, numAdsRequested)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAccessToken.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAccessToken.java
@@ -15,22 +15,15 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import java.util.Set;
+
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock1;
+import org.robovm.objc.block.VoidBlock3;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -62,9 +55,9 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAccessToken() {}
-    protected FBSDKAccessToken(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAccessToken(long handle) { super(handle); }
     protected FBSDKAccessToken(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithTokenString:permissions:declinedPermissions:appID:userID:expirationDate:refreshDate:")
+
     public FBSDKAccessToken(String tokenString, @org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> permissions, @org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> declinedPermissions, String appID, String userID, NSDate expirationDate, NSDate refreshDate) { super((SkipInit) null); initObject(init(tokenString, permissions, declinedPermissions, appID, userID, expirationDate, refreshDate)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAppEvents.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAppEvents.java
@@ -15,22 +15,14 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.block.VoidBlock1;
+import org.robovm.rt.bro.annotation.GlobalValue;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -57,7 +49,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAppEvents() {}
-    protected FBSDKAppEvents(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAppEvents(long handle) { super(handle); }
     protected FBSDKAppEvents(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAppLinkUtility.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAppLinkUtility.java
@@ -15,23 +15,12 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
-/*</imports>*/
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock2;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -46,7 +35,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAppLinkUtility() {}
-    protected FBSDKAppLinkUtility(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAppLinkUtility(long handle) { super(handle); }
     protected FBSDKAppLinkUtility(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKApplicationDelegate.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKApplicationDelegate.java
@@ -15,22 +15,14 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.apple.uikit.UIApplication;
+import org.robovm.apple.uikit.UIApplicationLaunchOptions;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,7 +38,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKApplicationDelegate() {}
-    protected FBSDKApplicationDelegate(Handle h, long handle) { super(h, handle); }
+    protected FBSDKApplicationDelegate(long handle) { super(handle); }
     protected FBSDKApplicationDelegate(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKButton.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKButton.java
@@ -15,22 +15,11 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.apple.uikit.UIButton;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,7 +35,6 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKButton() {}
-    protected FBSDKButton(Handle h, long handle) { super(h, handle); }
     protected FBSDKButton(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKGraphRequest.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKGraphRequest.java
@@ -15,22 +15,13 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock3;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,13 +37,13 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKGraphRequest() {}
-    protected FBSDKGraphRequest(Handle h, long handle) { super(h, handle); }
+    protected FBSDKGraphRequest(long handle) { super(handle); }
     protected FBSDKGraphRequest(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithGraphPath:parameters:")
+
     public FBSDKGraphRequest(String graphPath, NSDictionary<?, ?> parameters) { super((SkipInit) null); initObject(init(graphPath, parameters)); }
-    @Method(selector = "initWithGraphPath:parameters:HTTPMethod:")
+
     public FBSDKGraphRequest(String graphPath, NSDictionary<?, ?> parameters, String HTTPMethod) { super((SkipInit) null); initObject(init(graphPath, parameters, HTTPMethod)); }
-    @Method(selector = "initWithGraphPath:parameters:tokenString:version:HTTPMethod:")
+
     public FBSDKGraphRequest(String graphPath, NSDictionary<?, ?> parameters, String tokenString, String version, String HTTPMethod) { super((SkipInit) null); initObject(init(graphPath, parameters, tokenString, version, HTTPMethod)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKGraphRequestConnection.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKGraphRequestConnection.java
@@ -15,22 +15,12 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock3;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,7 +36,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKGraphRequestConnection() {}
-    protected FBSDKGraphRequestConnection(Handle h, long handle) { super(h, handle); }
+    protected FBSDKGraphRequestConnection(long handle) { super(handle); }
     protected FBSDKGraphRequestConnection(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKProfile.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKProfile.java
@@ -15,22 +15,13 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.coregraphics.CGSize;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock1;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -62,9 +53,9 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKProfile() {}
-    protected FBSDKProfile(Handle h, long handle) { super(h, handle); }
+    protected FBSDKProfile(long handle) { super(handle); }
     protected FBSDKProfile(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithUserID:firstName:middleName:lastName:name:linkURL:refreshDate:")
+
     public FBSDKProfile(String userID, String firstName, String middleName, String lastName, String name, NSURL linkURL, NSDate refreshDate) { super((SkipInit) null); initObject(init(userID, firstName, middleName, lastName, name, linkURL, refreshDate)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKProfilePictureView.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKProfilePictureView.java
@@ -15,22 +15,11 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,7 +35,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKProfilePictureView() {}
-    protected FBSDKProfilePictureView(Handle h, long handle) { super(h, handle); }
+    protected FBSDKProfilePictureView(long handle) { super(handle); }
     protected FBSDKProfilePictureView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKSettings.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKSettings.java
@@ -15,22 +15,15 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import java.util.Set;
+
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.MachineSizedFloat;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,7 +39,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKSettings() {}
-    protected FBSDKSettings(Handle h, long handle) { super(h, handle); }
+    protected FBSDKSettings(long handle) { super(handle); }
     protected FBSDKSettings(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKTestUsersManager.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKTestUsersManager.java
@@ -15,22 +15,15 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import java.util.Set;
+
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock1;
+import org.robovm.objc.block.VoidBlock2;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,7 +39,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKTestUsersManager() {}
-    protected FBSDKTestUsersManager(Handle h, long handle) { super(h, handle); }
+    protected FBSDKTestUsersManager(long handle) { super(handle); }
     protected FBSDKTestUsersManager(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKUtility.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKUtility.java
@@ -15,22 +15,12 @@
  */
 package org.robovm.pods.facebook.core;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.pods.bolts.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -46,7 +36,7 @@ import org.robovm.pods.bolts.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKUtility() {}
-    protected FBSDKUtility(Handle h, long handle) { super(h, handle); }
+    protected FBSDKUtility(long handle) { super(handle); }
     protected FBSDKUtility(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginButton.java
+++ b/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginButton.java
@@ -15,23 +15,15 @@
  */
 package org.robovm.pods.facebook.login;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.apple.accounts.*;
-import org.robovm.pods.facebook.core.*;
+import java.util.List;
+
+import org.robovm.apple.foundation.NSArray;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.pods.facebook.core.FBSDKButton;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -47,7 +39,6 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKLoginButton() {}
-    protected FBSDKLoginButton(Handle h, long handle) { super(h, handle); }
     protected FBSDKLoginButton(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginManager.java
+++ b/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginManager.java
@@ -15,23 +15,16 @@
  */
 package org.robovm.pods.facebook.login;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import java.util.List;
+
+import org.robovm.apple.accounts.ACAccountCredentialRenewResult;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.apple.accounts.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock2;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -47,7 +40,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKLoginManager() {}
-    protected FBSDKLoginManager(Handle h, long handle) { super(h, handle); }
+    protected FBSDKLoginManager(long handle) { super(handle); }
     protected FBSDKLoginManager(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginManagerLoginResult.java
+++ b/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginManagerLoginResult.java
@@ -15,23 +15,16 @@
  */
 package org.robovm.pods.facebook.login;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import java.util.Set;
+
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSSet;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.apple.accounts.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.pods.facebook.core.FBSDKAccessToken;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -47,9 +40,9 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKLoginManagerLoginResult() {}
-    protected FBSDKLoginManagerLoginResult(Handle h, long handle) { super(h, handle); }
+    protected FBSDKLoginManagerLoginResult(long handle) { super(handle); }
     protected FBSDKLoginManagerLoginResult(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithToken:isCancelled:grantedPermissions:declinedPermissions:")
+
     public FBSDKLoginManagerLoginResult(FBSDKAccessToken token, boolean isCancelled, @org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> grantedPermissions, @org.robovm.rt.bro.annotation.Marshaler(NSSet.AsStringSetMarshaler.class) Set<String> declinedPermissions) { super((SkipInit) null); initObject(init(token, isCancelled, grantedPermissions, declinedPermissions)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginTooltipView.java
+++ b/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKLoginTooltipView.java
@@ -15,23 +15,11 @@
  */
 package org.robovm.pods.facebook.login;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.apple.accounts.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -47,7 +35,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKLoginTooltipView() {}
-    protected FBSDKLoginTooltipView(Handle h, long handle) { super(h, handle); }
+    protected FBSDKLoginTooltipView(long handle) { super(handle); }
     protected FBSDKLoginTooltipView(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKTooltipView.java
+++ b/facebook/ios-login/src/main/java/org/robovm/pods/facebook/login/FBSDKTooltipView.java
@@ -15,23 +15,12 @@
  */
 package org.robovm.pods.facebook.login;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.coregraphics.CGPoint;
+import org.robovm.apple.uikit.UIView;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
 import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.apple.coregraphics.*;
-import org.robovm.apple.accounts.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -47,9 +36,9 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKTooltipView() {}
-    protected FBSDKTooltipView(Handle h, long handle) { super(h, handle); }
+    protected FBSDKTooltipView(long handle) { super(handle); }
     protected FBSDKTooltipView(SkipInit skipInit) { super(skipInit); }
-    @Method(selector = "initWithTagline:message:colorStyle:")
+
     public FBSDKTooltipView(String tagline, String message, FBSDKTooltipColorStyle colorStyle) { super((SkipInit) null); initObject(init(tagline, message, colorStyle)); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerBroadcastContext.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerBroadcastContext.java
@@ -15,20 +15,10 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +34,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerBroadcastContext() {}
-    protected FBSDKMessengerBroadcastContext(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerBroadcastContext(long handle) { super(handle); }
     protected FBSDKMessengerBroadcastContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerContext.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerContext.java
@@ -15,20 +15,11 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +35,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerContext() {}
-    protected FBSDKMessengerContext(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerContext(long handle) { super(handle); }
     protected FBSDKMessengerContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerShareButton.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerShareButton.java
@@ -15,20 +15,13 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.uikit.UIButton;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +37,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerShareButton() {}
-    protected FBSDKMessengerShareButton(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerShareButton(long handle) { super(handle); }
     protected FBSDKMessengerShareButton(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerShareOptions.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerShareOptions.java
@@ -15,20 +15,13 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSURL;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +37,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerShareOptions() {}
-    protected FBSDKMessengerShareOptions(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerShareOptions(long handle) { super(handle); }
     protected FBSDKMessengerShareOptions(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerSharer.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerSharer.java
@@ -15,21 +15,15 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import org.robovm.apple.foundation.NSData;
+import org.robovm.apple.foundation.NSObject;
 /*</imports>*/
+import org.robovm.apple.uikit.UIImage;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -44,7 +38,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerSharer() {}
-    protected FBSDKMessengerSharer(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerSharer(long handle) { super(handle); }
     protected FBSDKMessengerSharer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandler.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandler.java
@@ -15,20 +15,12 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSURL;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +36,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerURLHandler() {}
-    protected FBSDKMessengerURLHandler(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerURLHandler(long handle) { super(handle); }
     protected FBSDKMessengerURLHandler(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandlerCancelContext.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandlerCancelContext.java
@@ -15,20 +15,10 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +34,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerURLHandlerCancelContext() {}
-    protected FBSDKMessengerURLHandlerCancelContext(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerURLHandlerCancelContext(long handle) { super(handle); }
     protected FBSDKMessengerURLHandlerCancelContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandlerOpenFromComposerContext.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandlerOpenFromComposerContext.java
@@ -15,20 +15,14 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import java.util.Set;
+
+import org.robovm.apple.foundation.NSSet;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +38,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerURLHandlerOpenFromComposerContext() {}
-    protected FBSDKMessengerURLHandlerOpenFromComposerContext(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerURLHandlerOpenFromComposerContext(long handle) { super(handle); }
     protected FBSDKMessengerURLHandlerOpenFromComposerContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandlerReplyContext.java
+++ b/facebook/ios-messenger/src/main/java/org/robovm/pods/facebook/messenger/FBSDKMessengerURLHandlerReplyContext.java
@@ -15,20 +15,14 @@
  */
 package org.robovm.pods.facebook.messenger;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
+import java.util.Set;
+
+import org.robovm.apple.foundation.NSSet;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -44,7 +38,7 @@ import org.robovm.apple.uikit.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessengerURLHandlerReplyContext() {}
-    protected FBSDKMessengerURLHandlerReplyContext(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessengerURLHandlerReplyContext(long handle) { super(handle); }
     protected FBSDKMessengerURLHandlerReplyContext(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppGroupAddDialog.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppGroupAddDialog.java
@@ -15,22 +15,11 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
-/*</imports>*/
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,7 +34,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAppGroupAddDialog() {}
-    protected FBSDKAppGroupAddDialog(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAppGroupAddDialog(long handle) { super(handle); }
     protected FBSDKAppGroupAddDialog(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppGroupContent.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppGroupContent.java
@@ -15,21 +15,12 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.pods.facebook.core.FBSDKCopying;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +36,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAppGroupContent() {}
-    protected FBSDKAppGroupContent(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAppGroupContent(long handle) { super(handle); }
     protected FBSDKAppGroupContent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppGroupJoinDialog.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppGroupJoinDialog.java
@@ -15,21 +15,11 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +35,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAppGroupJoinDialog() {}
-    protected FBSDKAppGroupJoinDialog(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAppGroupJoinDialog(long handle) { super(handle); }
     protected FBSDKAppGroupJoinDialog(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppInviteContent.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppInviteContent.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSURL;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.pods.facebook.core.FBSDKCopying;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +37,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAppInviteContent() {}
-    protected FBSDKAppInviteContent(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAppInviteContent(long handle) { super(handle); }
     protected FBSDKAppInviteContent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppInviteDialog.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKAppInviteDialog.java
@@ -15,22 +15,12 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
-/*</imports>*/
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,7 +35,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKAppInviteDialog() {}
-    protected FBSDKAppInviteDialog(Handle h, long handle) { super(h, handle); }
+    protected FBSDKAppInviteDialog(long handle) { super(handle); }
     protected FBSDKAppInviteDialog(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKGameRequestContent.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKGameRequestContent.java
@@ -15,21 +15,15 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import java.util.List;
+
+import org.robovm.apple.foundation.NSArray;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.pods.facebook.core.FBSDKCopying;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +39,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKGameRequestContent() {}
-    protected FBSDKGameRequestContent(Handle h, long handle) { super(h, handle); }
+    protected FBSDKGameRequestContent(long handle) { super(handle); }
     protected FBSDKGameRequestContent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKGameRequestDialog.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKGameRequestDialog.java
@@ -15,21 +15,11 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +35,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKGameRequestDialog() {}
-    protected FBSDKGameRequestDialog(Handle h, long handle) { super(h, handle); }
+    protected FBSDKGameRequestDialog(long handle) { super(handle); }
     protected FBSDKGameRequestDialog(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKLikeButton.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKLikeButton.java
@@ -15,21 +15,12 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.pods.facebook.core.FBSDKButton;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +36,6 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKLikeButton() {}
-    protected FBSDKLikeButton(Handle h, long handle) { super(h, handle); }
     protected FBSDKLikeButton(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKLikeControl.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKLikeControl.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.apple.uikit.UIColor;
+import org.robovm.apple.uikit.UIControl;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +37,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKLikeControl() {}
-    protected FBSDKLikeControl(Handle h, long handle) { super(h, handle); }
+    protected FBSDKLikeControl(long handle) { super(handle); }
     protected FBSDKLikeControl(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKMessageDialog.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKMessageDialog.java
@@ -15,21 +15,11 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +35,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKMessageDialog() {}
-    protected FBSDKMessageDialog(Handle h, long handle) { super(h, handle); }
+    protected FBSDKMessageDialog(long handle) { super(handle); }
     protected FBSDKMessageDialog(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKSendButton.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKSendButton.java
@@ -15,21 +15,12 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.pods.facebook.core.FBSDKButton;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +36,6 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKSendButton() {}
-    protected FBSDKSendButton(Handle h, long handle) { super(h, handle); }
     protected FBSDKSendButton(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareAPI.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareAPI.java
@@ -15,22 +15,11 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
-/*</imports>*/
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,7 +34,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareAPI() {}
-    protected FBSDKShareAPI(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareAPI(long handle) { super(handle); }
     protected FBSDKShareAPI(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareButton.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareButton.java
@@ -15,21 +15,12 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.objc.annotation.Property;
+import org.robovm.pods.facebook.core.FBSDKButton;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +36,6 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareButton() {}
-    protected FBSDKShareButton(Handle h, long handle) { super(h, handle); }
     protected FBSDKShareButton(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareDialog.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareDialog.java
@@ -15,22 +15,12 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
-/*</imports>*/
+import org.robovm.apple.uikit.UIViewController;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,7 +35,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareDialog() {}
-    protected FBSDKShareDialog(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareDialog(long handle) { super(handle); }
     protected FBSDKShareDialog(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareLinkContent.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareLinkContent.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import java.util.List;
+
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +37,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareLinkContent() {}
-    protected FBSDKShareLinkContent(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareLinkContent(long handle) { super(handle); }
     protected FBSDKShareLinkContent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphAction.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphAction.java
@@ -15,22 +15,15 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSURL;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
 /*</imports>*/
+import org.robovm.pods.facebook.core.FBSDKCopying;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,11 +38,10 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareOpenGraphAction() {}
-    protected FBSDKShareOpenGraphAction(Handle h, long handle) { super(h, handle); }
     protected FBSDKShareOpenGraphAction(SkipInit skipInit) { super(skipInit); }
-    public FBSDKShareOpenGraphAction(String actionType, FBSDKShareOpenGraphObject object, String key) { super((Handle) null, create(actionType, object, key)); retain(getHandle()); }
-    public FBSDKShareOpenGraphAction(String actionType, String objectID, String key) { super((Handle) null, create(actionType, objectID, key)); retain(getHandle()); }
-    public FBSDKShareOpenGraphAction(String actionType, NSURL objectURL, String key) { super((Handle) null, create(actionType, objectURL, key)); retain(getHandle()); }
+    public FBSDKShareOpenGraphAction(String actionType, FBSDKShareOpenGraphObject object, String key) { super(create(actionType, object, key)); retain(getHandle()); }
+    public FBSDKShareOpenGraphAction(String actionType, String objectID, String key) { super(create(actionType, objectID, key)); retain(getHandle()); }
+    public FBSDKShareOpenGraphAction(String actionType, NSURL objectURL, String key) { super(create(actionType, objectURL, key)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "actionType")

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphContent.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphContent.java
@@ -15,22 +15,13 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import java.util.List;
+
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
-/*</imports>*/
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,7 +36,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareOpenGraphContent() {}
-    protected FBSDKShareOpenGraphContent(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareOpenGraphContent(long handle) { super(handle); }
     protected FBSDKShareOpenGraphContent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphObject.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphObject.java
@@ -15,21 +15,15 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.apple.foundation.NSDictionary;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.Method;
+import org.robovm.objc.annotation.NativeClass;
+import org.robovm.pods.facebook.core.FBSDKCopying;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +39,9 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareOpenGraphObject() {}
-    protected FBSDKShareOpenGraphObject(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareOpenGraphObject(long handle) { super(handle); }
     protected FBSDKShareOpenGraphObject(SkipInit skipInit) { super(skipInit); }
-    public FBSDKShareOpenGraphObject(NSDictionary<?, ?> properties) { super((Handle) null, create(properties)); retain(getHandle()); }
+    public FBSDKShareOpenGraphObject(NSDictionary<?, ?> properties) { super(create(properties)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphValueContainer.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareOpenGraphValueContainer.java
@@ -15,22 +15,13 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
-/*</imports>*/
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.VoidBlock3;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.BooleanPtr;
+import org.robovm.rt.bro.ptr.Ptr;
 
 /*<javadoc>*/
 
@@ -45,7 +36,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareOpenGraphValueContainer() {}
-    protected FBSDKShareOpenGraphValueContainer(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareOpenGraphValueContainer(long handle) { super(handle); }
     protected FBSDKShareOpenGraphValueContainer(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKSharePhoto.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKSharePhoto.java
@@ -15,21 +15,15 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSURL;
+import org.robovm.apple.uikit.UIImage;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.pods.facebook.core.FBSDKCopying;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,10 +39,10 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKSharePhoto() {}
-    protected FBSDKSharePhoto(Handle h, long handle) { super(h, handle); }
+    protected FBSDKSharePhoto(long handle) { super(handle); }
     protected FBSDKSharePhoto(SkipInit skipInit) { super(skipInit); }
-    public FBSDKSharePhoto(UIImage image, boolean userGenerated) { super((Handle) null, create(image, userGenerated)); retain(getHandle()); }
-    public FBSDKSharePhoto(NSURL imageURL, boolean userGenerated) { super((Handle) null, create(imageURL, userGenerated)); retain(getHandle()); }
+    public FBSDKSharePhoto(UIImage image, boolean userGenerated) { super(create(image, userGenerated)); retain(getHandle()); }
+    public FBSDKSharePhoto(NSURL imageURL, boolean userGenerated) { super(create(imageURL, userGenerated)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "image")

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKSharePhotoContent.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKSharePhotoContent.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import java.util.List;
+
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +37,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKSharePhotoContent() {}
-    protected FBSDKSharePhotoContent(Handle h, long handle) { super(h, handle); }
+    protected FBSDKSharePhotoContent(long handle) { super(handle); }
     protected FBSDKSharePhotoContent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareVideo.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareVideo.java
@@ -15,21 +15,14 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSURL;
+import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
-import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.pods.facebook.core.FBSDKCopying;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.annotation.Pointer;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,9 +38,9 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareVideo() {}
-    protected FBSDKShareVideo(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareVideo(long handle) { super(handle); }
     protected FBSDKShareVideo(SkipInit skipInit) { super(skipInit); }
-    public FBSDKShareVideo(NSURL videoURL) { super((Handle) null, create(videoURL)); retain(getHandle()); }
+    public FBSDKShareVideo(NSURL videoURL) { super(create(videoURL)); retain(getHandle()); }
     /*</constructors>*/
     /*<properties>*/
     @Property(selector = "videoURL")

--- a/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareVideoContent.java
+++ b/facebook/ios-share/src/main/java/org/robovm/pods/facebook/share/FBSDKShareVideoContent.java
@@ -15,21 +15,13 @@
  */
 package org.robovm.pods.facebook.share;
 
-/*<imports>*/
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import org.robovm.objc.*;
-import org.robovm.objc.annotation.*;
-import org.robovm.objc.block.*;
-import org.robovm.rt.*;
-import org.robovm.rt.annotation.*;
-import org.robovm.rt.bro.*;
-import org.robovm.rt.bro.annotation.*;
-import org.robovm.rt.bro.ptr.*;
+import java.util.List;
+
 import org.robovm.apple.foundation.*;
-import org.robovm.apple.uikit.*;
-import org.robovm.pods.facebook.core.*;
+import org.robovm.objc.ObjCRuntime;
+import org.robovm.objc.annotation.*;
+import org.robovm.rt.bro.annotation.Library;
+import org.robovm.rt.bro.ptr.Ptr;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -45,7 +37,7 @@ import org.robovm.pods.facebook.core.*;
     /*<constants>*//*</constants>*/
     /*<constructors>*/
     public FBSDKShareVideoContent() {}
-    protected FBSDKShareVideoContent(Handle h, long handle) { super(h, handle); }
+    protected FBSDKShareVideoContent(long handle) { super(handle); }
     protected FBSDKShareVideoContent(SkipInit skipInit) { super(skipInit); }
     /*</constructors>*/
     /*<properties>*/


### PR DESCRIPTION
Adjusted Facebook binding sources to be compatible with the current MobiDevelop/robovm snapshot.
- The constructors with `Handle` were replaced with `long` constructors except in the case of the button classes where the super class did not seem to support a long constructor.
- @Method annotations on constructors were removed
- imports were automatically organized to remove unused imports

Worth noting that it may be faster to create a `Handle` class as mentioned in https://github.com/MobiDevelop/robovm-robopods/issues/1, but this follows what appears to be the current backport convention that replaces the constructors. 

This has been tested in our use case of login and graph request, but not comprehensively tested.
