### PR TITLE
Updating Facebook bindings version readme to the latest

### DIFF
--- a/facebook/README.md
+++ b/facebook/README.md
@@ -4,14 +4,14 @@ Build, grow, and monetize your app with Facebook. The Facebook SDK allows you to
 
 ## Available RoboPods
 
-| Platform                          | Version | Description                                         |
-|-----------------------------------|---------|-----------------------------------------------------|
-| [ios](ios/)                       | 4.8.0   | Facebook iOS (all frameworks but AudienceNetwork)   |
-| [ios-audience](ios-audience/)     | 4.8.0   | Facebook iOS AudienceNetwork Framework              |
-| [ios-core](ios-core/)             | 4.8.0   | Facebook iOS CoreKit Framework                      |
-| [ios-login](ios-login/)           | 4.8.0   | Facebook iOS LoginKit Framework                     |
-| [ios-messenger](ios-messenger/)   | 4.8.0   | Facebook iOS MessengerShareKit Framework            |
-| [ios-share](ios-share/)           | 4.8.0   | Facebook iOS ShareKit Framework                     |
+| Platform                          | Version  | Description                                         |
+|-----------------------------------|----------|-----------------------------------------------------|
+| [ios](ios/)                       | 4.13.1   | Facebook iOS (all frameworks but AudienceNetwork)   |
+| [ios-audience](ios-audience/)     | 4.13.1   | Facebook iOS AudienceNetwork Framework              |
+| [ios-core](ios-core/)             | 4.13.1   | Facebook iOS CoreKit Framework                      |
+| [ios-login](ios-login/)           | 4.13.1   | Facebook iOS LoginKit Framework                     |
+| [ios-messenger](ios-messenger/)   | 4.13.1   | Facebook iOS MessengerShareKit Framework            |
+| [ios-share](ios-share/)           | 4.13.1   | Facebook iOS ShareKit Framework                     |
 
 ## Official website
 


### PR DESCRIPTION
There are no API changes between Facebook iOS SDK 4.8.0 and 4.13.1, might as well reference the latest version that has been (partially) tested.
