### PR TITLE
Replace NSPropertyList with NSObject in FBSDKApplicationDelegate.openURL

### DIFF
--- a/facebook/ios-core/src/main/bro-gen/facebook-corekit.yaml
+++ b/facebook/ios-core/src/main/bro-gen/facebook-corekit.yaml
@@ -77,9 +77,6 @@ classes:
         methods:
             '-application:openURL:sourceApplication:annotation:':
                 name: openURL
-                parameters:
-                    annotation:
-                        type: NSPropertyList
             '-application:didFinishLaunchingWithOptions:':
                 name: didFinishLaunching
                 parameters:

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKApplicationDelegate.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKApplicationDelegate.java
@@ -55,7 +55,7 @@ import org.robovm.pods.bolts.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "application:openURL:sourceApplication:annotation:")
-    public native boolean openURL(UIApplication application, NSURL url, String sourceApplication, NSPropertyList annotation);
+    public native boolean openURL(UIApplication application, NSURL url, String sourceApplication, NSObject annotation);
     @Method(selector = "application:didFinishLaunchingWithOptions:")
     public native boolean didFinishLaunching(UIApplication application, UIApplicationLaunchOptions launchOptions);
     @Method(selector = "sharedInstance")


### PR DESCRIPTION
I've seen on gitter that this was an issue. We changed it in UIApplicationDelegate, so it makes sense to change it here too. 
The type in Obj-C is `id` so in the end it should be NSObject, not NSPropertyList to be correct.

``` objc
- (BOOL)application:(UIApplication *)application
            openURL:(NSURL *)url
  sourceApplication:(NSString *)sourceApplication
         annotation:(id)annotation;
```
