### PR TITLE
bump the version to 2.3.0 to match latest robovm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ To prevent compatibility issues make sure that you use the same version for the 
 
 The current stable version is:
 
-> 2.2.0
+> 2.3.0
 
 If you want to use the latest and greatest of every RoboPod, use the latest snapshot version for your dependencies:
 
-> 2.2.1-SNAPSHOT
+> 2.3.0
 
 
 ## List of RoboPods

--- a/appmetrica/ios/pom.xml
+++ b/appmetrica/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-appmetrica-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-appmetrica-ios</artifactId>
     <name>RoboPods AppMetrica iOS</name>

--- a/appmetrica/pom.xml
+++ b/appmetrica/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-appmetrica-parent</artifactId>

--- a/bolts/ios/pom.xml
+++ b/bolts/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-bolts-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-bolts-ios</artifactId>
     <name>RoboPods Bolts iOS</name>

--- a/bolts/pom.xml
+++ b/bolts/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-bolts-parent</artifactId>

--- a/chartboost/ios/pom.xml
+++ b/chartboost/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-chartboost-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-chartboost-ios</artifactId>
     <name>RoboPods Chartboost iOS</name>

--- a/chartboost/pom.xml
+++ b/chartboost/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-chartboost-parent</artifactId>

--- a/fabric/ios-answers/pom.xml
+++ b/fabric/ios-answers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-fabric-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-fabric-ios-answers</artifactId>
     <name>RoboPods Fabric Answers iOS</name>

--- a/fabric/ios-crashlytics/pom.xml
+++ b/fabric/ios-crashlytics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-fabric-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-fabric-ios-crashlytics</artifactId>
     <name>RoboPods Fabric Crashlytics iOS</name>

--- a/fabric/ios-digits/pom.xml
+++ b/fabric/ios-digits/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-fabric-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-fabric-ios-digits</artifactId>
     <name>RoboPods Fabric Digits iOS</name>

--- a/fabric/ios-mopub/pom.xml
+++ b/fabric/ios-mopub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-fabric-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-fabric-ios-mopub</artifactId>
     <name>RoboPods Fabric MoPub iOS</name>

--- a/fabric/ios-twitter/pom.xml
+++ b/fabric/ios-twitter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-fabric-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-fabric-ios-twitter</artifactId>
     <name>RoboPods Fabric Twitter iOS</name>

--- a/fabric/ios-twittercore/pom.xml
+++ b/fabric/ios-twittercore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-fabric-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-fabric-ios-twittercore</artifactId>
     <name>RoboPods Fabric TwitterCore iOS</name>

--- a/fabric/ios/pom.xml
+++ b/fabric/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-fabric-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-fabric-ios</artifactId>
     <name>RoboPods Fabric iOS</name>

--- a/fabric/pom.xml
+++ b/fabric/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-fabric-parent</artifactId>

--- a/facebook/ios-audience/pom.xml
+++ b/facebook/ios-audience/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-facebook-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-facebook-ios-audience</artifactId>
     <name>RoboPods Facebook iOS - AudienceNetwork</name>

--- a/facebook/ios-core/pom.xml
+++ b/facebook/ios-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-facebook-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-facebook-ios-core</artifactId>
     <name>RoboPods Facebook iOS - CoreKit</name>

--- a/facebook/ios-login/pom.xml
+++ b/facebook/ios-login/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-facebook-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-facebook-ios-login</artifactId>
     <name>RoboPods Facebook iOS - LoginKit</name>

--- a/facebook/ios-messenger/pom.xml
+++ b/facebook/ios-messenger/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-facebook-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-facebook-ios-messenger</artifactId>
     <name>RoboPods Facebook iOS - MessengerShareKit</name>

--- a/facebook/ios-notifications/pom.xml
+++ b/facebook/ios-notifications/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-facebook-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-facebook-ios-notifications</artifactId>
     <name>RoboPods Facebook iOS - Notifications</name>

--- a/facebook/ios-share/pom.xml
+++ b/facebook/ios-share/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-facebook-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-facebook-ios-share</artifactId>
     <name>RoboPods Facebook iOS - ShareKit</name>

--- a/facebook/ios/pom.xml
+++ b/facebook/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-facebook-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-facebook-ios</artifactId>
     <name>RoboPods Facebook iOS</name>

--- a/facebook/pom.xml
+++ b/facebook/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-facebook-parent</artifactId>

--- a/flurry/ios-ads/pom.xml
+++ b/flurry/ios-ads/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-flurry-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-flurry-ios-ads</artifactId>
     <name>RoboPods Flurry Advertising iOS</name>

--- a/flurry/ios-analytics/pom.xml
+++ b/flurry/ios-analytics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-flurry-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-flurry-ios-analytics</artifactId>
     <name>RoboPods Flurry Analytics iOS</name>

--- a/flurry/ios/pom.xml
+++ b/flurry/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-flurry-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-flurry-ios</artifactId>
     <name>RoboPods Flurry iOS</name>

--- a/flurry/pom.xml
+++ b/flurry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-flurry-parent</artifactId>

--- a/google-analytics/ios-noads/pom.xml
+++ b/google-analytics/ios-noads/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-google-analytics-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-google-analytics-ios-noads</artifactId>
     <name>RoboPods Google Analytics iOS, without ad support</name>

--- a/google-analytics/ios/pom.xml
+++ b/google-analytics/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-google-analytics-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-google-analytics-ios</artifactId>
     <name>RoboPods Google Analytics iOS</name>

--- a/google-analytics/pom.xml
+++ b/google-analytics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-google-analytics-parent</artifactId>

--- a/google-apis/ios/pom.xml
+++ b/google-apis/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-google-apis-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-google-apis-ios</artifactId>
     <name>RoboPods Google APIs iOS</name>

--- a/google-apis/pom.xml
+++ b/google-apis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-google-apis-parent</artifactId>

--- a/google-mobile-ads/ios/pom.xml
+++ b/google-mobile-ads/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-google-mobile-ads-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-google-mobile-ads-ios</artifactId>
     <name>RoboPods Google Mobile Ads iOS</name>

--- a/google-mobile-ads/pom.xml
+++ b/google-mobile-ads/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-google-mobile-ads-parent</artifactId>

--- a/google-play-games/ios/README.md
+++ b/google-play-games/ios/README.md
@@ -72,7 +72,7 @@ Apply the following changes to your `robovm.xml` file:
 ### Gradle
 
 Make the following changes to your `build.gradle` file.
-Note that I had to use the 2.2.1-SNAPSHOT for robopods. The 2.2.0 version did not work for me.
+Note that I had to use the 2.3.0 for robopods. The 2.2.0 version did not work for me.
 
 ```
 allprojects {
@@ -84,7 +84,7 @@ allprojects {
         appName = "sample_ios_google_signin"
         gdxVersion = '1.9.4'
         roboVMVersion = '2.2.0'
-        robopodsVersion = '2.2.1-SNAPSHOT'				// Add
+        robopodsVersion = '2.3.0'				// Add
         box2DLightsVersion = '1.4'
         ashleyVersion = '1.7.0'
         aiVersion = '1.8.0'

--- a/google-play-games/ios/pom.xml
+++ b/google-play-games/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-google-play-games-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-google-play-games-ios</artifactId>
     <name>RoboPods Google Play Game Services iOS</name>

--- a/google-play-games/pom.xml
+++ b/google-play-games/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-google-play-games-parent</artifactId>

--- a/google-signin/ios/pom.xml
+++ b/google-signin/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-google-signin-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-google-signin-ios</artifactId>
     <name>RoboPods Google SignIn iOS</name>

--- a/google-signin/pom.xml
+++ b/google-signin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-google-signin-parent</artifactId>

--- a/heyzap/ios/pom.xml
+++ b/heyzap/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-heyzap-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-heyzap-ios</artifactId>
     <name>RoboPods Heyzap iOS</name>

--- a/heyzap/pom.xml
+++ b/heyzap/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-heyzap-parent</artifactId>

--- a/parse/ios/pom.xml
+++ b/parse/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parse-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-parse-ios</artifactId>
     <name>RoboPods Parse iOS</name>

--- a/parse/pom.xml
+++ b/parse/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-parse-parent</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-plugins-parent</artifactId>

--- a/plugins/robo.billing/android/pom.xml
+++ b/plugins/robo.billing/android/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-billing-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-billing-android</artifactId>
     <name>Robo.Billing Android</name>

--- a/plugins/robo.billing/core/pom.xml
+++ b/plugins/robo.billing/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-billing-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-billing-core</artifactId>
     <name>Robo.Billing Core</name>

--- a/plugins/robo.billing/ios/pom.xml
+++ b/plugins/robo.billing/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-billing-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-billing-ios</artifactId>
     <name>Robo.Billing iOS</name>

--- a/plugins/robo.billing/pom.xml
+++ b/plugins/robo.billing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-plugins-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-billing-parent</artifactId>

--- a/plugins/robo.core/pom.xml
+++ b/plugins/robo.core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-plugins-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-plugins-core</artifactId>
     <name>Robo.Core</name>

--- a/plugins/robo.dialog/android/pom.xml
+++ b/plugins/robo.dialog/android/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-dialog-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-dialog-android</artifactId>
     <name>Robo.Dialog Android</name>

--- a/plugins/robo.dialog/core/pom.xml
+++ b/plugins/robo.dialog/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-dialog-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-dialog-core</artifactId>
     <name>Robo.Dialog Core</name>

--- a/plugins/robo.dialog/ios/pom.xml
+++ b/plugins/robo.dialog/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-dialog-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-dialog-ios</artifactId>
     <name>Robo.Dialog iOS</name>

--- a/plugins/robo.dialog/pom.xml
+++ b/plugins/robo.dialog/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-plugins-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-dialog-parent</artifactId>

--- a/plugins/robo.settings/android/pom.xml
+++ b/plugins/robo.settings/android/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-settings-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-settings-android</artifactId>
     <name>Robo.Settings Android</name>

--- a/plugins/robo.settings/core/pom.xml
+++ b/plugins/robo.settings/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-settings-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-settings-core</artifactId>
     <name>Robo.Settings Core</name>

--- a/plugins/robo.settings/ios/pom.xml
+++ b/plugins/robo.settings/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-settings-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-settings-ios</artifactId>
     <name>Robo.Settings iOS</name>

--- a/plugins/robo.settings/pom.xml
+++ b/plugins/robo.settings/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-plugins-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-settings-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <groupId>com.mobidevelop.robovm</groupId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0</version>
     <artifactId>robopods-parent</artifactId>
     <name>RoboPods Parent</name>
     <packaging>pom</packaging>

--- a/reachability/ios/pom.xml
+++ b/reachability/ios/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-reachability-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>robopods-reachability-ios</artifactId>
     <name>RoboPods Network Reachability iOS</name>

--- a/reachability/pom.xml
+++ b/reachability/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.mobidevelop.robovm</groupId>
         <artifactId>robopods-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>robopods-reachability-parent</artifactId>


### PR DESCRIPTION
I believe we should bump the version to match the latest 2.3.0 release of RoboVM . I found incompatibilities with current snapshot release and robovm ( e.g Facebook core's FBSDKApplicationDelegate  openURL method signature mismatch) .Latest commits solves the problem . Using the new Robovm version , everything compiles and packages fine .