### PR TITLE
added basic support for ios banners for heyzap v10

### DIFF
--- a/heyzap/ios/src/main/java/org/robovm/pods/heyzap/ads/HZBannerAdController.java
+++ b/heyzap/ios/src/main/java/org/robovm/pods/heyzap/ads/HZBannerAdController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2013-2015 RoboVM AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.pods.heyzap.ads;
+
+/*<imports>*/
+import java.io.*;
+import java.nio.*;
+import java.util.*;
+import org.robovm.objc.*;
+import org.robovm.objc.annotation.*;
+import org.robovm.objc.block.*;
+import org.robovm.rt.*;
+import org.robovm.rt.annotation.*;
+import org.robovm.rt.bro.*;
+import org.robovm.rt.bro.annotation.*;
+import org.robovm.rt.bro.ptr.*;
+import org.robovm.apple.foundation.*;
+import org.robovm.apple.uikit.*;
+import org.robovm.apple.coregraphics.*;
+import org.robovm.apple.corelocation.*;
+import org.robovm.apple.storekit.*;
+import org.robovm.pods.heyzap.ads.*;
+/*</imports>*/
+
+/*<javadoc>*/
+
+/*</javadoc>*/
+/*<annotations>*/@Library(Library.INTERNAL) @NativeClass/*</annotations>*/
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/HZBannerAdController/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*//*</implements>*/ {
+
+    /*<constants>*//*</constants>*/
+    /*<constructors>*/
+    /*</constructors>*/
+    /*<properties>*/
+    @Property(selector = "sharedInstance")
+    public static native HZBannerAdController getSharedInstance();
+    /*</properties>*/
+    /*<members>*//*</members>*/
+    /*<methods>*/
+    @Method(selector = "requestBannerWithOptions:success:failure:")
+    public native void requestBanner(HZBannerAdOptions options, @Block VoidBlock1<UIView> success, @Block VoidBlock1<NSError> failure);
+    @Method(selector = "placeBannerAtPosition:options:success:failure:")
+    public native void placeBanner(HZBannerPosition position, HZBannerAdOptions options, @Block VoidBlock1<UIView> success, @Block VoidBlock1<NSError> failure);
+    /*</methods>*/
+}


### PR DESCRIPTION
Add basic methods to show banner ads on ios using heyzap sdk v10.
This was tested with old RoboVM 1.14, but should also work with new RoboVM fork.