### PR TITLE
Fixes missing/unncessary framework dependencies

### DIFF
--- a/google-mobile-ads/ios/src/main/robopods/META-INF/robovm/ios/robovm.xml
+++ b/google-mobile-ads/ios/src/main/robopods/META-INF/robovm/ios/robovm.xml
@@ -13,6 +13,7 @@
         <framework>GLKit</framework>
         <framework>MediaPlayer</framework>
         <framework>MessageUI</framework>
+        <framework>MobileCoreServices</framework>
         <framework>OpenGLES</framework>
         <framework>QuartzCore</framework>
         <framework>SafariServices</framework>

--- a/heyzap/ios/src/main/robopods/META-INF/robovm/ios/robovm.xml
+++ b/heyzap/ios/src/main/robopods/META-INF/robovm/ios/robovm.xml
@@ -17,8 +17,6 @@
         <framework>CoreMedia</framework>
         <framework>CoreMotion</framework>
         <framework>CoreTelephony</framework>
-        <framework>EventKit</framework>
-        <framework>EventKitUI</framework>
         <framework>MediaPlayer</framework>
         <framework>MessageUI</framework>
         <framework>MobileCoreServices</framework>


### PR DESCRIPTION
Added missing MobileCoreServices dependency to Google Mobile Ads (see Release Notes for version 7.10 https://firebase.google.com/docs/admob/release-notes#ios)

Removed HeyZap EventKit and EventKitUI (see https://developers.heyzap.com/docs/changelog). This change avoids the need to declare NSCalendarsUsageDescription when using HeyZap.