### PR TITLE
Added exportSymbols example to a Crashlytics README

### DIFF
--- a/fabric/ios-crashlytics/README.md
+++ b/fabric/ios-crashlytics/README.md
@@ -1,0 +1,10 @@
+# Crashlytics iOS Framework
+
+### RoboVM Configuration
+In addition to adding the robopod and framework dependencies, Crashlytics requires the following symbols to run. Add these into `robovm.xml`
+
+```
+    <exportedSymbols>
+        <symbol>CLS*</symbol>
+    </exportedSymbols>
+```


### PR DESCRIPTION
This tripped us up a little, trying to import our first pod. Hopefully this helps the next person.