### PR TITLE
Facebook: fix signature of openURL method

### DIFF
--- a/facebook/ios-core/src/main/bro-gen/facebook-corekit.yaml
+++ b/facebook/ios-core/src/main/bro-gen/facebook-corekit.yaml
@@ -77,6 +77,9 @@ classes:
         methods:
             '-application:openURL:sourceApplication:annotation:':
                 name: openURL
+                parameters:
+                    annotation:
+                        type: ObjCProtocol
             '-application:didFinishLaunchingWithOptions:':
                 name: didFinishLaunching
                 parameters:

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAppLinkUtility.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKAppLinkUtility.java
@@ -56,6 +56,8 @@ import org.robovm.pods.bolts.*;
     /*<methods>*/
     @Method(selector = "fetchDeferredAppLink:")
     public static native void fetchDeferredAppLink(@Block VoidBlock2<NSURL, NSError> handler);
+    @Method(selector = "fetchDeferredAppInvite:")
+    public static native boolean fetchDeferredAppInvite(@Block VoidBlock1<NSURL> handler);
     @Method(selector = "appInvitePromotionCodeFromURL:")
     public static native String getAppInvitePromotionCodeFromURL(NSURL url);
     /*</methods>*/

--- a/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKApplicationDelegate.java
+++ b/facebook/ios-core/src/main/java/org/robovm/pods/facebook/core/FBSDKApplicationDelegate.java
@@ -55,7 +55,7 @@ import org.robovm.pods.bolts.*;
     /*<members>*//*</members>*/
     /*<methods>*/
     @Method(selector = "application:openURL:sourceApplication:annotation:")
-    public native boolean openURL(UIApplication application, NSURL url, String sourceApplication, NSObject annotation);
+    public native boolean openURL(UIApplication application, NSURL url, String sourceApplication, ObjCProtocol annotation);
     @Method(selector = "application:didFinishLaunchingWithOptions:")
     public native boolean didFinishLaunching(UIApplication application, UIApplicationLaunchOptions launchOptions);
     @Method(selector = "sharedInstance")


### PR DESCRIPTION
1. This fix is related to the corresponding fix in the UIKit, see:
https://github.com/MobiVM/robovm/commit/7cb74213b5d4b036ba01cd63ca9771e1230bd153
(search for openURL)

In UIKit, the openURL method has now the following signature:
`openURL(UIApplication application, NSURL url, String sourceApplication, NSPropertyList annotation)`

NSPropertyList does not extend NSObject, however it extends NSObjectProtocol > ObjCProtocol.
So I've changed the method from Facebook SDK to accept ObjCProtocol.

2. fetchDeferredAppInvite method did appear because of using of the newest version of bro-gen (I'm sure however)