### PR TITLE
Instructions how to add Native frameworks, Fabric

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the dependencies to your project and start coding without thinking about pla
 
 A RoboPod comes in form of a simple JAR file published to Maven Central so you can easily 
 integrate it with Maven or Gradle.
-Just add a depencency to your Maven or Gradle build files and you are ready to go!
+Add a depencency to your Maven or Gradle build files, download native frameworks, define frameworks in robovm.xml and you are ready to go!
 
 ### Versioning
 
@@ -58,6 +58,34 @@ When you add a dependency, you can refer to the variable like this:
    <version>${robopods.version}</version>
 </dependency>
 ```
+
+#### Add native frameworks
+
+Native frameworks can be embedded in the Robopod jars, but often need to be added manually. A robopod jar has embedded its native frameworks if in path `META-INF/robovm/ios/libs/` `.framework` or `.a` files are present.
+
+If natives are not present, you need to add them manually. Download the native frameworks, add them to the project and update robovm.xml.
+
+Below an example if you'd like to use the Facebook SDK Share dialog.
+
+Download the iOS SDK from [https://developers.facebook.com/docs/ios/downloads](https://developers.facebook.com/docs/ios/downloads)
+
+Copy the Bolts.framework, FBSDKCoreKit.framework and FBSDKShareKit.framework
+into ./lib (relative to robovm.xml)
+
+Add to robovm.xml:
+    
+    <frameworkPaths>
+        <path>lib</path>
+    </frameworkPaths>
+    
+    
+    <frameworks>
+        ...
+        <framework>Bolts</framework>
+        <framework>FBSDKCoreKit</framework>
+        <framework>FBSDKShareKit</framework>
+        ...
+    </frameworks>
 
 #### Current versions
 

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -15,3 +15,22 @@
 ## Official website
 
 https://fabric.io/
+
+## Getting started
+
+### Make app available in the Fabric.io dashboard
+
+* Download `Fabric.app` and integrate Fabric in a dummy Xcode project using `Fabric.app`.  This dummy app must have the  `Bundle Identifier` of the Robovm app.
+* Run the Xcode dummy app once on a device.
+* App should now become visible in the Fabric.io dashboard within minutes.
+
+### Integrate in Robovm app
+
+* Download libraries from Fabric website (don't use CocoaPods, as they need manual processing; website download `com.twitter.crashlytics.ios-manual.zip` contains .framework directories that can be used in Robovm unmodified)
+* Add Fabric RoboPods to `pom.xml` / `build.gradle`
+* In IosApplication.Delegate.didFinishLaunching, initialize Fabric (using `Fabric.with`)
+
+## Further reading
+
+* Also check the README files of the various Fabric RoboPods for specific instructions per Pod.
+ 

--- a/fabric/ios-crashlytics/README.md
+++ b/fabric/ios-crashlytics/README.md
@@ -1,12 +1,4 @@
 # Crashlytics iOS Framework
 
-### RoboVM Configuration
-In addition to adding the robopod and framework dependencies, Crashlytics requires the following symbols to run. Add these into `robovm.xml`
-
-```
-    <exportedSymbols>
-        <symbol>CLS*</symbol>
-    </exportedSymbols>
-```
-
-Forward uncaught runtime exceptions to Crashlytics crash reporter by calling `org.robovm.apple.foundation.NSException#registerDefaultJavaUncaughtExceptionHandler` in `com.badlogic.gdx.backends.iosrobovm.IOSApplication.Delegate#didFinishLaunching`.
+# RoboVM Configuration
+In addition to adding the robopod and framework dependencies, you need to configure Robovm to report uncaught exceptions as crashes. Call `org.robovm.apple.foundation.NSException#registerDefaultJavaUncaughtExceptionHandler` in `com.badlogic.gdx.backends.iosrobovm.IOSApplication.Delegate#didFinishLaunching`.

--- a/fabric/ios-crashlytics/README.md
+++ b/fabric/ios-crashlytics/README.md
@@ -8,3 +8,5 @@ In addition to adding the robopod and framework dependencies, Crashlytics requir
         <symbol>CLS*</symbol>
     </exportedSymbols>
 ```
+
+Forward uncaught runtime exceptions to Crashlytics crash reporter by calling `org.robovm.apple.foundation.NSException#registerDefaultJavaUncaughtExceptionHandler` in `com.badlogic.gdx.backends.iosrobovm.IOSApplication.Delegate#didFinishLaunching`.

--- a/fabric/ios-crashlytics/src/main/robopods/META-INF/robovm/ios/robovm.xml
+++ b/fabric/ios-crashlytics/src/main/robopods/META-INF/robovm/ios/robovm.xml
@@ -9,4 +9,7 @@
         <framework>SystemConfiguration</framework>
         <framework>Security</framework>
     </frameworks>
+    <exportedSymbols>
+        <symbol>CLS*</symbol>
+    </exportedSymbols>
 </config>


### PR DESCRIPTION
In earlier versions of Robovm, native frameworks where always embedded
in JAR files. Most newer libraries no longer do that.