### PR TITLE
Update bindings to Appodeal 2

### DIFF
--- a/appodeal/README.md
+++ b/appodeal/README.md
@@ -7,7 +7,7 @@ The mobile ad network Appodeal runs multiple premium networks under one integrat
 
 | Platform            | Version |
 |---------------------|---------|
-| [iOS](ios/)         | 1.3.3   |
+| [iOS](ios/)         | 2.1.4   |
 |                     |         |
 
 ## Official website

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDBannerView.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDBannerView.h
@@ -2,14 +2,20 @@
 //  APDBannerView.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
 #import <Appodeal/APDSdk.h>
 
-@class APDBannerView;
+#ifdef ADVANCED_INTEGRATION
+#import <Appodeal/AppodealRequestDelegateProtocol.h>
+#endif
 
+
+@class APDBannerView;
 /*!
  *  Declaration of banner view delegate
  */
@@ -18,36 +24,44 @@
 @optional
 
 /*!
- *  Method called when banner view did load in first time
+ *  Method called when banner view loaded on first attempt
  *
  *  @param bannerView Ready banner view
  */
 - (void)bannerViewDidLoadAd:(APDBannerView *)bannerView;
 
 /*!
- *  Method called when precache (cheap and fast load) banner view did load
- *  After refresh will be show usual banner if loaded
+ *  Method called when precache banner view loaded
+ *  After refresh, usual banner will be shown if loaded
  *  @param precacheBannerView Ready precache
  */
-- (void)precacheBannerViewDidLoadAd:(APDBannerView *)precacheBannerView;
+- (void)precacheBannerViewDidLoadAd:(APDBannerView *)precacheBannerView __attribute__((deprecated("Use -bannerViewDidLoadAd: instead")));
+
+/*!
+ *  Method called after any banner was shown or refreshed
+ *
+ *  @param bannerView On screen banner view
+ */
+- (void)bannerViewDidShow:(APDBannerView *)bannerView;
+
 
 /*!
  *  Method called after any banner refresh
  *
  *  @param bannerView On screen banner view
  */
-- (void)bannerViewDidRefresh:(APDBannerView *)bannerView;
+- (void)bannerViewDidRefresh:(APDBannerView *)bannerView __attribute__((deprecated("Use -bannerViewDidShow: instead")));
 
 /*!
- *  Method called if banner view if banner mediation failed
+ *  Method called if banner view mediation failed
  *
  *  @param bannerView Failed banner
- *  @param error      Occured error
+ *  @param error      Occurred error
  */
 - (void)bannerView:(APDBannerView *)bannerView didFailToLoadAdWithError:(NSError *)error;
 
 /*!
- *  Call when user tap on banner
+ *  Call when user taps on banner
  *
  *  @param bannerView On screen banner view
  */
@@ -56,32 +70,36 @@
 @end
 
 
-@interface APDBannerView : UIView
+@interface APDBannerView : UIView 
 
+#ifdef ADVANCED_INTEGRATION
+@property (weak, nonatomic) IBOutlet id<APDBannerViewRequestDelegate> requestDelegate;
+#endif
 /*!
  *  Set banner view delegate
  */
 @property (weak, nonatomic) IBOutlet id<APDBannerViewDelegate> delegate;
 
 /*!
- *  Set nonnul root view controller before load banner view
+ *  Set non-null root view controller before loading banner view
  */
 @property (weak, nonatomic) IBOutlet UIViewController *rootViewController;
 
 /*!
- *  Set custom placed, tuned on Appodeal Dashboard
+ *  Set custom placement, turned on in Appodeal Dashboard
  */
 @property (copy, nonatomic) IBInspectable NSString *placement;
 
 /*!
- *  If this flag set YES banner view will autoresize after screen rotation
- *  By default set to NO
+ *  If this flag is set to YES, banner view will auto-resize after screen rotation
+ *  (It is possible to use the flag only if the application supports one orientation)
+ *  Set to NO by default
  */
 @property (assign, nonatomic) IBInspectable BOOL usesSmartSizing;
 
 /*!
- *  If this flag set to YES banner view will refreshing after refresh interval tuned in Appodeal Dashboard
- *  Default set to YES
+ *  If this flag is set to YES, banner view will refresh after refresh interval turned on in Appodeal Dashboard
+ *  Set to YES by default
  */
 @property (assign, nonatomic) IBInspectable BOOL autoRefreshing;
 
@@ -91,27 +109,27 @@
 @property (assign, nonatomic) IBInspectable CGSize adSize;
 
 /*!
- *  @brief Set banner refreshing
+ *  Set banner refresh animation
  */
 @property (assign, nonatomic) IBInspectable UIViewAnimationOptions refreshAnimation;
 
 /*!
- *  @brief Set banner background visability
+ *  Set banner background visibility
  */
 @property (assign, nonatomic) BOOL backgroundVisible;
 
 /*!
- *  Set custom sdk
+ *  Set custom SDK
  */
 @property (weak, nonatomic) APDSdk *customSdk;
 
 /*!
- *  Getter banner availability
+ *  Get banner availability
  */
 @property (assign, nonatomic, readonly, getter=isReady) BOOL ready;
 
 /*!
- *  Iitializator
+ *  Initializer
  *
  *  @param adSize kAPDAdSize320x50, kAPDAdSize728x90
  *
@@ -125,12 +143,7 @@
 - (void)loadAd;
 
 /*!
- *  Start loading precache banner, after that automatically usual load start
- */
-- (void)loadAdWhithPrecache;
-
-/*!
- *  Call this method when orientation change
+ *  Call this method when orientation changes
  *
  *  @param orientation Current interface orientation
  */

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDDefines.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDDefines.h
@@ -2,11 +2,379 @@
 //  APDDefines.h
 //  Appodeal
 //
-//  Copyright © 2015 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
+
+FOUNDATION_EXPORT const CGSize kAppodealUnitSize_320x50;
+FOUNDATION_EXPORT const CGSize kAppodealUnitSize_300x250;
+FOUNDATION_EXPORT const CGSize kAppodealUnitSize_728x90;
+
+FOUNDATION_EXPORT NSArray * AppodealAvailableUnitSizes();
+
+FOUNDATION_EXPORT BOOL AppodealIsUnitSizeSupported(const CGSize size, NSArray *supportedSizes);
+FOUNDATION_EXPORT BOOL AppodealIsUnitSizeAvailable(const CGSize size);
+
+
+FOUNDATION_EXPORT CGSize AppodealNearestUnitSizeForSize(CGSize size);
+
+/*!
+ *  Appodeal ads types
+ */
+typedef NS_OPTIONS(NSInteger, AppodealAdType) {
+    /*!
+     *  Interstitial
+     */
+    AppodealAdTypeInterstitial      = 1 << 0,
+    /*!
+     *  Skippable video (can be skipped by user after several seconds of watch)
+     */
+    AppodealAdTypeSkippableVideo __attribute__((deprecated("Use AppodealAdTypeInterstitial")))   = 1 << 1,
+    /*!
+     *  Banner ads
+     */
+    AppodealAdTypeBanner            = 1 << 2,
+    /*!
+     *  Native ads
+     */
+    AppodealAdTypeNativeAd          = 1 << 3,
+    /*!
+     *  Rewarded video (return reward parameter in finish callback, can not be skipped by user)
+     */
+    AppodealAdTypeRewardedVideo     = 1 << 4,
+    /*!
+     *  Rectangle banner of size 300 x 250
+     */
+    AppodealAdTypeMREC              = 1 << 5,
+    /*!
+     *  Non-skippable video (does not return reward parameter in finish callback, can not be skipped by user)
+     */
+    AppodealAdTypeNonSkippableVideo = 1 << 6,
+};
+
+/*!
+ *  Appodeal styles to show
+ */
+typedef NS_OPTIONS(NSInteger, AppodealShowStyle) {
+    /*!
+     *  Show interstial ads
+     */
+    AppodealShowStyleInterstitial       = 1 << 0,
+    /*!
+     *  Show skippable ads
+     */
+    AppodealShowStyleSkippableVideo __attribute__((deprecated("Use bit mask AppodealShowStyleInterstitial")))  = AppodealShowStyleInterstitial,
+    /*!
+     *  - If both are ready, show ad with higher eCPM
+     *  @discussion - If one of this type is ready, show ad
+     *  @discussion - If none are ready, wait for the first ready ad
+     */
+    AppodealShowStyleVideoOrInterstitial __attribute__((deprecated("Use bit mask AppodealShowStyleInterstitial"))) = AppodealShowStyleInterstitial,
+    /*!
+     *  Show banner at top of screen
+     */
+    AppodealShowStyleBannerTop          = 1 << 2,
+    /*!
+     *  Show banner at bottom of screen
+     */
+    AppodealShowStyleBannerBottom       = 1 << 3,
+    /*!
+     *  Show rewareded video
+     */
+    AppodealShowStyleRewardedVideo      = 1 << 4,
+    /*!
+     *  Show non-skippable video
+     */
+    AppodealShowStyleNonSkippableVideo  = 1 << 5
+};
+
+typedef NS_ENUM(NSUInteger, AppodealUserGender) {
+    AppodealUserGenderOther = 0,
+    AppodealUserGenderFemale,
+    AppodealUserGenderMale
+};
+
+typedef NS_ENUM(NSUInteger, AppodealUserOccupation) {
+    AppodealUserOccupationOther = 0,
+    AppodealUserOccupationWork,
+    AppodealUserOccupationSchool,
+    AppodealUserOccupationUniversity
+};
+
+typedef NS_ENUM(NSUInteger, AppodealUserRelationship) {
+    AppodealUserRelationshipOther = 0,
+    AppodealUserRelationshipSingle,
+    AppodealUserRelationshipDating,
+    AppodealUserRelationshipEngaged,
+    AppodealUserRelationshipMarried,
+    AppodealUserRelationshipSearching
+};
+
+typedef NS_ENUM(NSUInteger, AppodealUserSmokingAttitude) {
+    AppodealUserSmokingAttitudeNegative = 1,
+    AppodealUserSmokingAttitudeNeutral,
+    AppodealUserSmokingAttitudePositive
+};
+
+typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
+    AppodealUserAlcoholAttitudeNegative = 1,
+    AppodealUserAlcoholAttitudeNeutral,
+    AppodealUserAlcoholAttitudePositive
+};
+
+/*!
+ *  Declaration of banner delegate
+ */
+@protocol AppodealBannerDelegate <NSObject>
+
+@optional
+/*!
+ *  Method called when precached or usual banner view loads
+ *
+ *  @param precache If precache is YES it means that precached ad loaded
+ */
+- (void)bannerDidLoadAdIsPrecache:(BOOL)precache;
+
+/*!
+ *  Method called when banner loaded and is ready to show
+ */
+- (void)bannerDidLoadAd __attribute__((deprecated("Use -bannerDidLoadAdisPrecache:precache: instead")));
+
+/*!
+ *  Method called when banner refreshes
+ */
+- (void)bannerDidRefresh __attribute__((deprecated("Use -bannerDidShow instead")));
+
+/*!
+ *  Method called if banner mediation failed
+ */
+- (void)bannerDidFailToLoadAd;
+
+/*!
+ *  Method called when user taps on banner
+ */
+- (void)bannerDidClick;
+
+/*!
+ *  Method called when banner shows or refreshes
+ */
+- (void)bannerDidShow;
+
+@end
+
+/*!
+ *  Interstital delegate declaration
+ */
+@protocol AppodealInterstitialDelegate <NSObject>
+
+@optional
+
+/*!
+ *  Method called when usual interstitial view loads
+ *
+ */
+- (void)interstitialDidLoadAd __attribute__((deprecated("Use -interstitialDidLoadAdisPrecache: instead")));
+
+/*!
+ *  Method called when precached or usual interstitial view loads
+ *  @warning If you want show only expensive ads, ignore this callback call with precache equal to YES
+ *
+ *  @param precache If precache is YES it means that precached ad loaded
+ */
+- (void)interstitialDidLoadAdisPrecache:(BOOL)precache;
+
+/*!
+ *  Method called if interstitial mediation failed
+ */
+- (void)interstitialDidFailToLoadAd;
+
+/*!
+ *  Method called if interstitial mediation was successful, but ready ad network can't show ad or
+ *  ad presentation was too frequent according to your placement settings
+ */
+- (void)interstitialDidFailToPresent;
+
+/*!
+ *  Method called when interstitial displays on screen
+ */
+- (void)interstitialWillPresent;
+
+/*!
+ *  Method called after interstitial leaves the screen
+ */
+- (void)interstitialDidDismiss;
+
+/*!
+ *  Method called when user taps on interstitial
+ */
+- (void)interstitialDidClick;
+
+@end
+
+
+/*!
+ *  Rewarded video delegate declaration
+ */
+@protocol AppodealRewardedVideoDelegate <NSObject>
+
+@optional
+
+/*!
+ *  Method called when rewarded video loads
+ */
+- (void)rewardedVideoDidLoadAd;
+
+/*!
+ *  Method called if rewarded video mediation failed
+ */
+- (void)rewardedVideoDidFailToLoadAd;
+
+/*!
+ *  Method called if interstitial mediation was successful, but ready ad network can't show ad or
+ *  ad presentation was too frequent according to your placement settings
+ */
+- (void)rewardedVideoDidFailToPresent;
+
+/*!
+ *  Method called after rewarded video starts displaying
+ */
+- (void)rewardedVideoDidPresent;
+
+/*!
+ *  Method called before rewarded video leaves screen
+ */
+- (void)rewardedVideoWillDismiss;
+
+/*!
+ *  Method called after completion of video
+ *  @warning After calling this method, rewarded video can stay on screen and show postbanner
+ *
+ *  @param rewardAmount Amount of app currency turned on in Appodeal Dashboard
+ *  @param rewardName Name of app currency set on in Appodeal Dashboard
+ */
+- (void)rewardedVideoDidFinish:(NSUInteger)rewardAmount name:(NSString *)rewardName;
+
+/*!
+ *  Method called after user taps on screen
+ *  @warning Not all ad networks provide this callback!
+ */
+- (void)rewardedVideoDidClick __attribute__((deprecated("Not all ad networks return this action")));
+
+@end
+
+
+/*!
+ *  Non-skippable video delegate
+ */
+@protocol AppodealNonSkippableVideoDelegate <NSObject>
+
+@optional
+
+/*!
+ *  Method called when non skippable video loads
+ */
+- (void)nonSkippableVideoDidLoadAd;
+
+/*!
+ *  Mehtod called if non-skippable video mediation failed
+ */
+- (void)nonSkippableVideoDidFailToLoadAd;
+
+/*!
+ *  Method called after non-skippable video starts displaying
+ */
+- (void)nonSkippableVideoDidPresent;
+
+/*!
+ *  Method called if non-skippable mediation was successful, but ready ad network can't show ad or
+ *  ad presentation was too frequent according to your placement settings
+ */
+- (void)nonSkippableVideoDidFailToPresent;
+
+/*!
+ *  Method called before non-skippable video leaves screen
+ */
+- (void)nonSkippableVideoWillDismiss;
+
+/*!
+ *  Method called after completion of video
+ *  @warning After calling this method, non-skippable video can stay on screen and show postbanner
+ *
+ */
+- (void)nonSkippableVideoDidFinish;
+
+/*!
+ *  Method called after user taps on screen
+ *  @warning Not all ad networks provide this callback!
+ */
+- (void)nonSkippableVideoDidClick __attribute__((deprecated("Not all ad networks return this action")));
+
+@end
+
+
+
+/*!
+ *  Skippable video delegate
+ */
+@protocol AppodealSkippableVideoDelegate <NSObject>
+
+@optional
+
+/*!
+ *  Method called when skippable video loads
+ */
+- (void)skippableVideoDidLoadAd;
+
+/*!
+ *  Method called if skippable video mediation failed
+ */
+- (void)skippableVideoDidFailToLoadAd;
+
+/*!
+ *  Method called after skippable video starts displaying
+ */
+- (void)skippableVideoDidPresent;
+
+/*!
+ *  Method called before skippable video leaves screen
+ */
+- (void)skippableVideoWillDismiss;
+
+/*!
+ *  Method called after completion of video: if user skips the video, this callback is not called
+ *  @warning After calling this method, skippable video can stay on screen and show postbanner
+ *  @warning Not all ad networks provide this callback!
+ *
+ */
+- (void)skippableVideoDidFinish;
+
+/*!
+ *  Method called after user taps on screen
+ *  @warning Not all ad networks provide this callback!
+ */
+- (void)skippableVideoDidClick;
+
+@end
+
+
+@protocol AppodealNativeAdDelegate <NSObject>
+
+/*!
+ *  Method called after native ads load
+ */
+- (void)didLoadNativeAds:(NSInteger)count;
+
+/*!
+ *  Method called if native ads get some error while loading
+ */
+- (void)didFailToLoadNativeAdsWithError:(NSError *)error;
+
+@end
+
 
 /*!
  *  Default APDBanner sizes
@@ -31,7 +399,7 @@ extern const CGSize kAPDImageSizeUndefined;
 extern BOOL   APDIsAdSizeValid(const CGSize size);
 
 /*!
- *  Getter of nearest appodeal valid size
+ *  Get nearest valid Appodeal size
  *
  *  @param size CGSize
  *
@@ -40,9 +408,9 @@ extern BOOL   APDIsAdSizeValid(const CGSize size);
 extern CGSize APDNearestValidAdSizeForCGSize(const CGSize size);
 
 /*!
- *  Getter of current sdk version
+ *  Get current SDK version
  *
- *  @return current sdk version
+ *  @return current SDK version
  */
 NSString * APDSdkVersionString();
 
@@ -57,8 +425,8 @@ typedef NS_ENUM(NSInteger, APDError) {
      */
     APDUnknownError = 195944097,
     /*!
-     * Inconsistency error, occure for example if some kind 
-     * of ads start loading, but APDSdk does not initialized 
+     * Inconsistency error: occurrs for example if some kind
+     * of ads start loading, but APDSdk does not initialize
      * for this type
      */
     APDInternalInconsistencyError,
@@ -67,8 +435,12 @@ typedef NS_ENUM(NSInteger, APDError) {
      */
     APDNetworkingError,
     /*!
-     *  Errors of this type occure if some network responses contains
-     *  data of unsupported/unexpected type
+     *  Device is not reachable
+     */
+    APDDeviceNotReachableError,
+    /*!
+     *  Errors of this type occur if some network response contains
+     *  data of an unsupported/unexpected type
      */
     APDJSONDecodeError,
     /*!
@@ -84,17 +456,33 @@ typedef NS_ENUM(NSInteger, APDError) {
      */
     APDPresentationError,
     /*!
+     *  Device offline or ready ad does not conform to presentation settings
+     */
+    APDInconsistencyPresentationError,
+    /*!
      *  Inconsistency size
      */
     APDInvalidAdSizeError,
+    /*!
+     *  Handled exception size
+     */
+    APDHandledExceptionError,
     /*!
      *  Invalid type was loaded
      */
     APDInvalidAdTypeError,
     /*!
+     *  Ad unit returned from server contains invalid data
+     */
+    APDIncorrectAdUnitError,
+    /*!
      *  Error while unarchiving cached data
      */
-    APDUnarchiveError
+    APDUnarchiveError,
+    /*!
+     *  Insufficiently device's current memory
+     */
+    APDLowMemoryError
 };
 
 
@@ -103,26 +491,26 @@ typedef NS_ENUM(NSInteger, APDError) {
  */
 typedef NS_OPTIONS(NSUInteger, APDLogFlag) {
     /*!
-     *  Only error messages is writed to console.
-     *  If you see this messages, you must to 
+     *  Only error messages are written to console.
+     *  If you see this message, you must
      *  check your integration
      */
     APDLogFlagError   = 1 << 0,
     /*!
-     *  Warning and error messages is writed to console.
-     *  Different warnings occured while sdk work
+     *  Warning and error messages are written to console.
+     *  Different warnings occur while the SDK works
      */
     APDLogFlagWarning = 1 << 1,
     /*!
-     *  Erorr, warning and information messages is writed to console.
+     *  Error, warning and information messages are written to console.
      */
     APDLogFlagInfo    = 1 << 2,
     /*!
-     *  Debug messages writed to console
+     *  Debug messages written to console
      */
     APDLogFlagDebug   = 1 << 3,
     /*!
-     *  All sdk messages writed to console
+     *  All SDK messages written to console
      */
     APDlogFlagVerbose = 1 << 4
 };
@@ -136,26 +524,26 @@ typedef NS_ENUM(NSUInteger, APDLogLevel) {
      */
     APDLogLevelOff     = 0,
     /*!
-     *  Only error messages is writed to console.
-     *  If you see this messages, you must to
+     *  Only error messages are written to console.
+     *  If you see this message, you must
      *  check your integration
      */
     APDLogLevelError   = APDLogFlagError,
     /*!
-     *  Warning and error messages is writed to console.
-     *  Different warnings occured while sdk work
+     *  Warning and error messages are written to console.
+     *  Different warnings occur while the SDK works
      */
     APDLogLevelWarning = APDLogLevelError   | APDLogFlagWarning,
     /*!
-     *  Erorr, warning and information messages is writed to console.
+     *  Error, warning and information messages are written to console.
      */
     APDLogLevelInfo    = APDLogLevelWarning | APDLogFlagInfo,
     /*!
-     *  Debug messages writed to console
+     *  Debug messages written to console
      */
     APDLogLevelDebug   = APDLogLevelInfo    | APDLogFlagDebug,
     /*!
-     *  All sdk messages writed to console
+     *  All SDK messages written to console
      */
     APDLogLevelVerbose = APDLogLevelDebug   | APDlogFlagVerbose
 };
@@ -165,31 +553,31 @@ typedef NS_ENUM(NSUInteger, APDLogLevel) {
  *  several ad types, by usage binary operand |
  *  For example: APDAdTypeInterstitialAd | APDAdTypeSkippableVideo
  */
-typedef NS_OPTIONS(NSUInteger, APDAdType) {
+typedef NS_OPTIONS(NSUInteger, APDType) {
     /*!
      *  Interstital ad
      */
-    APDAdTypeInterstitialAd = 1 << 0,
+    APDTypeInterstitialAd = 1 << 0,
     /*!
-     *  Skippavle video ad
+     *  Skippable video ad
      */
-    APDAdTypeSkippableVideo = 1 << 1,
+    APDTypeSkippableVideo __attribute__((deprecated("Use APDAdTypeInterstitialAd instead"))) = 1 << 1,
     /*!
      *  Banner ad
      */
-    APDAdTypeBanner         = 1 << 2,
+    APDTypeBanner         = 1 << 2,
     /*!
      *  Native ad
      */
-    APDAdTypeNativeAd       = 1 << 3,
+    APDTypeNativeAd       = 1 << 3,
     /*!
      *  Rewarded ad
      */
-    APDAdTypeRewardedVideo  = 1 << 4,
+    APDTypeRewardedVideo  = 1 << 4,
     /*!
-     *  Rectangle banner (banner of size 300x250)
+     *  Rectangular banner (banner of size 300x250)
      */
-    APDAdTypeMREC           = 1 << 5
+    APDTypeMREC           = 1 << 5
 };
 
 /*!
@@ -197,8 +585,8 @@ typedef NS_OPTIONS(NSUInteger, APDAdType) {
  */
 typedef NS_ENUM(NSUInteger, APDNativeAdType) {
     /*!
-     * Native ad loaded can contains video
-     * It's depend filled ad network
+     * Native ad loaded can contain video
+     * It depends on filled ad’s network
      */
     APDNativeAdTypeAuto = 0,
     /*!
@@ -230,11 +618,11 @@ typedef NS_ENUM(NSUInteger, APDUserGender) {
 };
 
 /*!
- *  User ocupation
+ *  User occupation
  */
 typedef NS_ENUM(NSUInteger, APDUserOccupation) {
     /*!
-     *  User's occupation is undefined / not contains in other values
+     *  User's occupation is undefined / not one of the other values
      */
     APDUserOccupationOther = 0,
     /*!
@@ -256,7 +644,7 @@ typedef NS_ENUM(NSUInteger, APDUserOccupation) {
  */
 typedef NS_ENUM(NSUInteger, APDUserRelationship) {
     /*!
-     *  User's relationship is undefined / not contains in other values
+     *  User's relationship is undefined / not one of the other values
      */
     APDUserRelationshipOther = 0,
     /*!
@@ -282,19 +670,19 @@ typedef NS_ENUM(NSUInteger, APDUserRelationship) {
 };
 
 /*!
- *  User smoking attitued
+ *  User smoking attitude
  */
 typedef NS_ENUM(NSUInteger, APDUserSmokingAttitude) {
     /*!
-     *  Doesn't smoke
+     *  Negative
      */
     APDUserSmokingAttitudeNegative = 1,
     /*!
-     *  Neutral position
+     *  Neutral
      */
     APDUserSmokingAttitudeNeutral,
     /*!
-     *  Smoke
+     *  Positive
      */
     APDUserSmokingAttitudePositive
 };
@@ -336,7 +724,8 @@ typedef NS_ENUM(NSUInteger, APDFramework) {
     APDFrameworkReactNative,
     APDFrameworkCorona,
     APDFrameworkStencyl,
-    APDFrameworkSDKBox
+    APDFrameworkSDKBox,
+    APDFrameworkDefold
 };
 
 

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDImage.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDImage.h
@@ -2,14 +2,16 @@
 //  APDImage.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 
 /*!
- *  Instance of this class contains url to image source and size of image
+ *  Instance of this class contains URL to image source and size of image
  */
 @interface APDImage : NSObject
 

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDInterstitialAd.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDInterstitialAd.h
@@ -2,12 +2,18 @@
 //  APDInterstital.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <Appodeal/APDSdk.h>
+
+#ifdef ADVANCED_INTEGRATION
+#import <Appodeal/AppodealRequestDelegateProtocol.h>
+#endif
 
 @class APDInterstitialAd;
 
@@ -19,22 +25,22 @@
 @optional
 
 /*!
- *  Method called when interstital did load
+ *  Method called when interstitial loads
  *
  *  @param interstitialAd Instance of ready to show interstitial
  */
 - (void)interstitialAdDidLoad:(APDInterstitialAd *)interstitialAd;
 
 /*!
- *  Method called if precache interstitial (cheap and fast loading) did load.
- *  If you want to show only expensive ad ignore this method!
+ *  Method called if precached interstitial loads.
+ *  If you want to show only expensive ads, ignore this method!
  *
  *  @param precacheInterstitial Instance of ready interstitial
  */
 - (void)precacheInterstitialAdDidLoad:(APDInterstitialAd *)precacheInterstitial;
 
 /*!
- *  Method called if interstitial mediation attempt was unsucessfull
+ *  Method called if interstitial mediation attempt was unsuccessful
  *
  *  @param interstitialAd Instance of failed interstitial
  *  @param error          Mediation error
@@ -42,7 +48,7 @@
 - (void)interstitialAd:(APDInterstitialAd *)interstitialAd didFailToLoadWithError:(NSError *)error;
 
 /*!
- *  Method called when interstitial did show on screen
+ *  Method called when interstitial shows on screen
  *
  *  @param interstitialAd Shown interstitial
  */
@@ -57,7 +63,7 @@
 
 /*!
  *  Method called in case that interstitial failed while showing
- *  For example current ad network occure error
+ *  For example an error occurs in current ad network
  *
  *  @param interstitialAd Shown interstitial
  *  @param error          Error
@@ -65,18 +71,19 @@
 - (void)interstitialAd:(APDInterstitialAd *)interstitialAd didFailToPresentWithError:(NSError *)error;
 
 /*!
- *  Call when user tap on interstital
+ *  Call when user taps on interstitial
  *
  *  @param interstitialAd Shown interstitial
- */- (void)interstitialAdDidRecieveTapAction:(APDInterstitialAd *)interstitialAd;
+ */
+- (void)interstitialAdDidRecieveTapAction:(APDInterstitialAd *)interstitialAd;
 
 @end
 
 
 /*!
- *  You should have strong refrence on loading interstial instance
- *  Instance of interstital ad can try to load ad only once!
- *  Create new interstial before any call -loadAd!
+ *  You should have strong reference on the instance of loading an interstitial
+ *  Instance of interstitial ad can try to load ad only once!
+ *  Create new interstitial before any call -loadAd!
  *  @code - (void) loadInterstitial {
         self.interstital = [APDInterstitialAd new];
         self.interstital.delegate = self;
@@ -85,39 +92,42 @@
  */
 @interface APDInterstitialAd : NSObject
 
+#ifdef ADVANCED_INTEGRATION
+@property (weak, nonatomic) id<APDInterstitalAdRequestDelegate> requestDelegate;
+#endif
 /*!
  *  Set interstitial delegate
  */
 @property (weak, nonatomic) id<APDInterstitalAdDelegate> delegate;
 
 /*!
- *  Set custom placement name, that you create in Appodeal Dashbord
+ *  Set custom placement name, that you create in Appodeal Dashboard
  */
 @property (copy, nonatomic) NSString *placement;
 
 /*!
- *  Set custom sdk
+ *  Set custom SDK
  */
 @property (weak, nonatomic) APDSdk *customSdk;
 
 /*!
- *  Getter interstital availability
+ *  Get interstitial availability
  */
 @property (assign, nonatomic, readonly, getter=isReady) BOOL ready;
 
 
 /*!
- *  Getter interstitial already show
+ *  Get interstitial already shown
  */
 @property (assign, nonatomic, readonly) BOOL hasBeenPresented;
 
 /*!
- *  Start interstiail loading
+ *  Start loading interstitial
  */
 - (void)loadAd;
 
 /*!
- *  Show ready interstital from view controller
+ *  Show ready interstitial from view controller
  *
  *  @param viewController Current presented view controller
  */

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDMRECView.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDMRECView.h
@@ -2,14 +2,16 @@
 //  APDMRECView.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Appodeal/APDBannerView.h>
 
 /*!
- * Instance of this class return rectangle banner of size 300x250
- * All methods/properties besides initilizer similar to APDBannerView
+ * Instance of this class returns rectangular banner of size 300x250
+ * All methods/properties besides initializer similar to APDBannerView
  */
 @interface APDMRECView : APDBannerView
 

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDMediaView.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDMediaView.h
@@ -2,7 +2,9 @@
 //  APDMediaView.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
@@ -14,15 +16,15 @@
  */
 typedef NS_ENUM(NSInteger, APDMediaViewType) {
     /*!
-     *  Placeholder is main image image. When video loaded on media view
-     *  play button appear. Wnen play button will tapped, video start play on with media view size
-     *  if media view tapped
+     *  Placeholder is main image. When the video loads on media view,
+     *  the play button appears. When the play button is tapped, the video starts to play with media view size on
+     *  if media view is tapped
      */
     APDMediaViewTypeMainImage = 0,
     /*!
-     *  Placeholder is icon image. When video loaded autostart is ignoring on media view
-     *  play button appear. Wnen play button will tapped, video start play on full screen.
-     *  Tap on video in fullscreen mode return video to media view size
+     *  Placeholder is icon image. When autostart is ignored on media view,
+     *  the play button appears. When play button is tapped, video starts to play on full screen.
+     *  Tap on video in fullscreen mode to return video to media view size.
      */
     APDMediaViewTypeIcon
 };
@@ -37,33 +39,33 @@ typedef NS_ENUM(NSInteger, APDMediaViewType) {
 @optional
 
 /*!
- *  Method called when media view start playing
+ *  Method called when media view starts playing
  *
  *  @param mediaView Current media view
  */
 - (void)mediaViewStartPlaying:(APDMediaView *)mediaView;
 
 /*!
- *  Method called when media view finish playing
+ *  Method called when media view finishes playing
  *
  *  @param mediaView  Current media view
- *  @param wasSkipped If user skipp video from media view return YES else return NO
+ *  @param wasSkipped If user skips video from media view return YES else return NO
  */
 - (void)mediaViewFinishPlaying:(APDMediaView *)mediaView videoWasSkipped:(BOOL)wasSkipped;
 
 /*!
- *  @brief Method called when media view present fullscreen
+ *  Method called when media view presents fullscreen
  *  If type APDMediaViewTypeIcon -mediaViewStartPlaying: call firstly!
- *  When this method called media view has fullscreen size
+ *  When this method is called, media view has fullscreen size
  *
  *  @param mediaView     Current media view
- *  @param presentedView At this view you can place custom controls element, for example mute button
+ *  @param presentedView At this view you can place custom controls elements: for example, a mute button
  */
 - (void)mediaView:(APDMediaView *)mediaView didPresentFullScreenView:(UIView *)presentedView;
 
 /*!
- *  Method called when media view dismiss fullscreen
- *  When this method called media view has original size;
+ *  Method called when media view dismisses fullscreen
+ *  When this method is called, media view has original size;
  *
  *  @param mediaView Current media view
  */
@@ -73,10 +75,10 @@ typedef NS_ENUM(NSInteger, APDMediaViewType) {
 
 /*!
  *  Instance of this class provides video player for instances of APDNativeAd.
- *  Placeholder image depend of media view type and can be mainImage or iconImage from native ad.
- *  If native ad doesn't contain video only placeholder be displayed.
- *  If video played and visability of media view change and be less than 80% video will stop.
- *  Autoplay parameter tuned on Appodeal Dashboard.
+ *  Placeholder image depends on media view type and can be mainImage or iconImage from native ad.
+ *  If native ad doesn't contain video, only placeholder be displayed.
+ *  If the video is played and visibility of the media view changes to less than 80%, the video will stop.
+ *  Autoplay parameter tuned on in Appodeal Dashboard.
  *  Example:
  * @code
  - (void)addMediaViewToView:(UIView *)view fromViewController:(UIViewController<APDMediaViewDelegate> *)controller nativeAd:(APDNativeAd:)nativeAd {
@@ -101,42 +103,42 @@ typedef NS_ENUM(NSInteger, APDMediaViewType) {
  *  Current media view type. Default set to APDMediaViewTypeMainImage.
  *  @warning Set type before calling - setNativeAd:rootViewController:
  */
-@property (nonatomic, assign) APDMediaViewType type;
+@property (nonatomic, assign) APDMediaViewType type __attribute__((deprecated("Media View has APDMediaViewTypeMainImage type only!")));
 
 /*!
- *  If set to YES, after 5 seconds after video start playing skipp button appear.
- * Tap on skipp button will close video
+ *  If set to YES, 5 seconds after the video starts playing, the skip button will appear.
+ * Tapping on the skip button will close the video
  * -mediaViewFinishPlaying:videoWasSkipped: return wasSkipped = YES.
- * By default set to YES.
+ * Set to YES by default
  */
-@property (nonatomic, assign) BOOL skippable;
+@property (nonatomic, assign) BOOL skippable __attribute__((deprecated("All native videos can be skipped by user")));
 
 
 /*!
- *  Video sound contorol
+ *  Video sound control
  *  Call this for example in - mediaViewStartPlaying:
- *  Default set to NO
+ *  Set to NO by default
  */
-@property (nonatomic, assign) BOOL muted;
+@property (nonatomic, assign) BOOL muted __attribute__((deprecated("Contolled by user")));
 
 /*!
- *  Video sound contorol
+ *  Video sound control
  *  Call this for example in - mediaViewStartPlaying:
  *  Default set to YES
  */
-@property (nonatomic, assign) BOOL useDefaultMuteButton;
+@property (nonatomic, assign) BOOL useDefaultMuteButton __attribute__((deprecated("Always YES")));
 
 /*!
- *  Set native ad to media view. If native ad contains video it start cache video and present this when become visible and video be ready
+ *  Set native ad to media view. If native ad contains video it starts to cache the video and presents it when it becomes visible and the video is ready
  *
  *  @param nativeAd  Nonnul native ad
- *  @param clearView Nonnul controller
+ *  @param controller Nonnul controller
  */
 - (void)setNativeAd:(APDNativeAd *)nativeAd rootViewController:(UIViewController *)controller;
 
 /*!
- *  If you use media view in custom table/collection view without helper and want to reuse 
- *  media view any times call with method before reuse
+ *  If you use media view in custom table/collection view without helper and want to reuse
+ *  media view any time, call with method before reuse
  */
 - (void)clearView;
 

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDNativeAd.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDNativeAd.h
@@ -2,75 +2,98 @@
 //  APDNativeAd.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import <Appodeal/APDImage.h>
 #import <UIKit/UIKit.h>
 
+@class APDNativeAd;
+
+
+typedef NS_ENUM(NSUInteger, APDNativeComplainPosition) {
+    APDComplainNone = 0,
+    APDComplainTop,
+    APDComplainCenter,
+    APDComplainBottom
+};
+
+@protocol APDNativeAdPresentationDelegate <NSObject>
+
+@optional
+
+- (void)nativeAdWillLogImpression:(APDNativeAd *)nativeAd;
+
+- (void)nativeAdWillLogUserInteraction:(APDNativeAd *)nativeAd;
+
+@end
+
 /*!
- *  Instance of this class contain ad data
+ *  Instance of this class contains ad data
  */
 @interface APDNativeAd : NSObject
 
+@property (nonatomic, weak) id <APDNativeAdPresentationDelegate> delegate;
+
 /*!
- *  Ad title, required field to display. Length less than or equal to about 120 characters
+ *  Ad title, required field to display. Length less than or equal to about 120 characters.
  */
 @property (copy, nonatomic, readonly) NSString *title;
 
 /*!
- *  Ad subtitle, optional field to display
+ *  Ad subtitle, optional field to display.
  */
 @property (copy, nonatomic, readonly) NSString *subtitle;
 
 /*!
- *  Ad description, optional field to display. Length less than or equal to about 400 characters
+ *  Ad description, optional field to display. Length less than or equal to about 400 characters.
  */
 @property (copy, nonatomic, readonly) NSString *descriptionText;
 
 /*!
- *  Ad call to action text, required field to display. Length less than or equal to about 120 characters
+ *  Ad call to action text, required field to display. Length less than or equal to about 120 characters.
  */
 @property (copy, nonatomic, readonly) NSString *callToActionText;
 
 /*!
- *  Ad content rating to action text, optional field to display. Length less than or equal to about 120 characters
+ *  Ad content rating to action text, optional field to display. Length less than or equal to about 120 characters.
  */
 @property (copy, nonatomic, readonly) NSString *contentRating;
 
 /*!
- *  Rating of advertised app, optional field
+ *  Rating of advertised app, optional field.
  */
 @property (copy, nonatomic, readonly) NSNumber *starRating;
 
 /*!
- *  Main image from native ad. Prevalent aspect ratio is 16:9. Optional
+ *  Main image from native ad, optional field. Prevalent aspect ratio is 16:9.
  */
 @property (copy, nonatomic, readonly) APDImage *mainImage;
 
 /*!
- *  Square icon image. Prevalent sizes 50x50, 80x80. Requered
+ *  Square icon image, required field. Prevalent sizes 50x50, 80x80.
  */
 @property (copy, nonatomic, readonly) APDImage *iconImage;
 
 /*!
- *  Ad Choices view. Can be nil. Provided by ad network. If contains requered to display!. Minimum size 24x24
+ *  Ad Choices view. Can be nil. Provided by ad network. If it contains data, required to display. Minimum size 24x24.
  */
 @property (nonatomic, strong, readonly) UIView * adChoicesView;
 
 /*!
- *  Getter that native ad contains video
+ *  Gets that native ad contains video
  */
 @property (nonatomic, readonly, getter=isContainsVideo) BOOL containsVideo;
 
-
 /*!
- *  Call this method before displying native ad! 
- *  Need to track impressions/tap actions!
+ *  Call this method before displaying native ad
+ *  Need to track impressions/tap actions
  *
- *  @param view           Nonnul view that contains all required fields and will be displayed
- *  @param viewController Nonnul view controller that will display view
+ *  @param view           Non-null view that contains all required fields and will be displayed
+ *  @param viewController Non-null view controller that will display view
  */
 - (void)attachToView:(UIView *)view viewController:(UIViewController *)viewController;
 
@@ -80,5 +103,7 @@
  *  Disable native ad tracking mechanism for current native ad view
  */
 - (void)detachFromView;
+
+- (void)complainButtonPositon:(APDNativeComplainPosition)position;
 
 @end

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDNativeAdLoader.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDNativeAdLoader.h
@@ -2,7 +2,9 @@
 //  APDNativeAdLoader.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -13,35 +15,46 @@
 
 @class APDNativeAdLoader;
 
+@protocol APDNativeAdRequestDelegate <NSObject>
+
+@optional
+
+- (void)nativeAdLoaderDidStartMediation:(APDNativeAdLoader *)nativeAdLoader;
+- (void)nativeAdLoader:(APDNativeAdLoader *)nativeAdLoader willSendRequestToAdNetwork:(NSString *)adNetwork;
+- (void)nativeAdLoader:(APDNativeAdLoader *)nativeAdLoader didRecieveResponseFromAdNetwork:(NSString *)adNetwork wasFilled:(BOOL)filled;
+- (void)nativeAdLoader:(APDNativeAdLoader *)nativeAdLoader didFinishMediationAdWasFilled:(BOOL)filled;
+
+@end
+
 /*!
  *  Declaration of native ad loader delegate
  */
 @protocol APDNativeAdLoaderDelegate <NSObject>
 
 /*!
- *  Method called when loader recieve native ad.
- *  Count of array can be little than requested capacity
+ *  Method called when loader receives native ad.
+ *  Count of array can be less than requested capacity
  *
- *  @brief This API will be available in future release
+ *  @discussion This API will be available in future release
  *
- *  @param loader    Ready loader
+ *  @param loader    Loader is ready
  *  @param nativeAds Array of native ads of requested type
  */
-- (void)nativeAdLoader:(APDNativeAdLoader *)loader didLoadNativeAds:(NSArray <__kindof APDNativeAd *> *)nativeAds NS_UNAVAILABLE;
+- (void)nativeAdLoader:(APDNativeAdLoader *)loader didLoadNativeAds:(NSArray <__kindof APDNativeAd *> *)nativeAds;
 
 /*!
- *  Method called when loaded recieve native ad.
+ *  Method called when received native ad is loaded
  *
- *  @param loader   Ready loader
+ *  @param loader   Loader is ready
  *  @param nativeAd Native ad to show
  */
-- (void)nativeAdLoader:(APDNativeAdLoader *)loader didLoadNativeAd:(APDNativeAd *)nativeAd;
+- (void)nativeAdLoader:(APDNativeAdLoader *)loader didLoadNativeAd:(APDNativeAd *)nativeAd NS_UNAVAILABLE;
 
 /*!
  *  Method called if loader mediation failed
  *
  *  @param loader Failed loader
- *  @param error  Occured error
+ *  @param error  Error occurred
  */
 - (void)nativeAdLoader:(APDNativeAdLoader *)loader didFailToLoadWithError:(NSError *)error;
 
@@ -52,24 +65,27 @@
  */
 @interface APDNativeAdLoader : NSObject
 
+
+@property (weak, nonatomic) id<APDNativeAdRequestDelegate> requestDelegate;
+
 /*!
  *  Set loader delegate
  */
 @property (weak, nonatomic) id<APDNativeAdLoaderDelegate> delegate;
 
 /*!
- *  Set custom placement tuned on Appodeal Dashboard
+ *  Set custom placement turned on in Appodeal Dashboard
  */
 @property (copy, nonatomic) NSString *placement;
 
 /*!
- *  Set custom sdk
+ *  Set custom SDK
  */
 @property (weak, nonatomic) APDSdk *customSdk;
 
 /*!
- *  Call this method to load native ad.
- *  Capacity equals to 1, it's means that array of native ads
+ *  Call this method to load native ads.
+ *  If the capacity is equal to 1, it means that the array of native ads
  *  returned in -nativeAdLoader: didLoadNativeAds: will contain
  *  only one instance of native ad
  *
@@ -78,16 +94,17 @@
 - (void)loadAdWithType:(APDNativeAdType)type;
 
 /*!
- *  Call this method to load native ad.
- *  Capacity equals to 1, it's means that array of native ads
+ *  Call this method to load native ads.
+ *  If the capacity is equal , it means that the  array of native ads
  *  returned in -nativeAdLoader: didLoadNativeAds: will contain
  *  only one instance of native ad
  *
- *  @brief This API will be available in future release
+ *
  *
  *  @param type     Native ad type
- *  @param capacity Interger value from 1 to 11
+ *  @param capacity Integer value from 1 to 11
  */
-- (void)loadAdWithType:(APDNativeAdType)type capacity:(NSInteger)capacity NS_UNAVAILABLE;
+- (void)loadAdWithType:(APDNativeAdType)type capacity:(NSInteger)capacity;
+
 
 @end

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDNativeAdQueue.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDNativeAdQueue.h
@@ -1,0 +1,82 @@
+//
+//  APDNativeAdQueue.h
+//  Appodeal
+//
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Appodeal/APDNativeAd.h>
+#import <Appodeal/APDDefines.h>
+
+
+@class APDNativeAdQueue;
+
+
+@protocol APDNativeAdQueueDelegate <NSObject>
+
+@optional
+
+/**
+ Method called when loader receives native ad.
+ 
+ @param adQueue ad queue object
+ @param count count of available native ad
+ */
+- (void)adQueueAdIsAvailable:(APDNativeAdQueue *)adQueue ofCount:(NSInteger)count;
+
+
+/**
+ Method called when loader fails to receive native ad.
+ 
+ @param adQueue ad queue object
+ @param error Error occurred
+ */
+- (void)adQueue:(APDNativeAdQueue *)adQueue failedWithError:(NSError *)error;
+
+@end
+
+
+@interface APDNativeAdQueue : NSObject
+
+/*!
+ *  Set loader delegate
+ */
+@property (nonatomic, weak) id<APDNativeAdQueueDelegate> delegate;
+
+
+/**
+ * Get count of available native ads
+ */
+@property (nonatomic, readonly, assign) NSInteger currentAdCount;
+
+
+/**
+ Set max count of native ads
+ 
+ @param adSize max count of native ad
+ */
+
+- (void)setMaxAdSize:(NSInteger)adSize;
+
+
+/**
+ * Call this method to load native ads
+ 
+ @param type APDNativeAdTypeAuto or APDNativeAdTypeVideo or APDNativeAdTypeNoVideo
+ */
+- (void)loadAdOfType:(APDNativeAdType)type;
+
+
+/**
+ Call this method to get native ads
+ 
+ @param count count available native ads
+ @return array of native ad
+ */
+- (NSArray <__kindof APDNativeAd *> *)getNativeAdsOfCount:(NSInteger)count;
+
+
+@end

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDRewardProtocol.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDRewardProtocol.h
@@ -2,14 +2,16 @@
 //  APDRewardProtocol.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 
 
 /*!
- *  Declaration of appodeal reward protocol object
+ *  Declaration of Appodeal reward protocol object
  */
 @protocol APDReward <NSObject>
 

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDRewardedVideo.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDRewardedVideo.h
@@ -2,7 +2,9 @@
 //  APDReviewVideo.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -11,8 +13,11 @@
 #import <Appodeal/APDSdk.h>
 #import <Appodeal/APDRewardProtocol.h>
 
-@class APDRewardedVideo;
+#ifdef ADVANCED_INTEGRATION
+#import <Appodeal/AppodealRequestDelegateProtocol.h>
+#endif
 
+@class APDRewardedVideo;
 
 /*!
  *  Declaration of rewarded video delegate
@@ -22,73 +27,76 @@
 @optional
 
 /*!
- *  Method called when rewarded video did load
+ *  Method called when rewarded video loads
  *
  *  @param rewardedVideo Ready to show rewarded video
  */
 - (void)rewardedVideoDidLoad:(APDRewardedVideo *)rewardedVideo;
 
 /*!
- *  Method called if skippable rewarded mediation was failed
+ *  Method called if skippable rewarded mediation failed
  *
  *  @param rewardedVideo Failed rewarded video
  */
 - (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo didFailToLoadWithError:(NSError *)error;
 
 /*!
- *  Method called if rewarded video adapter become unavailable
- *  This case can occure only for singleton ad networks: AdColony, Vungle, Unity
+ *  Method called if rewarded video adapter becomes unavailable
+ *  This case can occur only for singleton ad networks: AdColony, Vungle, Unity
  *
  *  @param rewardedVideo Failed rewarded video
  */
 - (void)rewardedVideoDidBecomeUnavailable:(APDRewardedVideo *)rewardedVideo;
 
 /*!
- *  Method called after rewarded video did show
+ *  Method called after rewarded video shows
  *
  *  @param rewardedVideo Shown rewarded video
  */
 - (void)rewardedVideoDidAppear:(APDRewardedVideo *)rewardedVideo;
 
 /*!
- *  Method called after rewarded video did dismiss from screen
+ *  Method called after rewarded video is dismissed from screen
  *
  *  @param rewardedVideo Shown rewarded video
  */
 - (void)rewardedVideoDidDisappear:(APDRewardedVideo *)rewardedVideo;
 
 /*!
- *   Method called after rewarded video did finish
- *   @warning After call this method video controller can show postbanner 
+ *   Method called after rewarded video completes
+ *   @warning After calling this method video controller can show postbanner
  *   view and stay on screen.
  *
- *  @param rewardedVideo Finished rewarded video
- *  @param reward        Object conformed APDReward protocol with values tunned by Dashboard
+ *  @param rewardedVideo Completed rewarded video
+ *  @param reward        Object conformed APDReward protocol with values turned on in Appodeal Dashboard
  */
 - (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo didFinishWithReward:(id<APDReward>)reward;
 
 /*!
- *  Method called if rewarded video adapter occure some error while presenting
+ *  Method called if an error occurs while presenting the rewarded video adapter
  *
  *  @param rewardedVideo  Failed rewarded video
- *  @param error          Occured error
+ *  @param error          Error occurred
  */
-
 - (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo didFailToPresentWithError:(NSError *)error;
 
 @end
 
 /*!
- *  You should have strong refrence on loading rewarded video instance
+ *  You should have strong reference on loading rewarded video instance
  *  Instance of rewarded video ad can try to load ad only once!
  *  Create new rewarded video before any call -loadAd!
  *  @code - (void) loadRewardedVideo {
- self.rewardedVideo = [APDRewaredVideo new];
- self.rewardedVideo.delegate = self;
- [self.rewardedVideo loadAd]
- }
+            self.rewardedVideo = [APDRewaredVideo new];
+            self.rewardedVideo.delegate = self;
+            [self.rewardedVideo loadAd]
+        }
  */
 @interface APDRewardedVideo : NSObject
+
+#ifdef ADVANCED_INTEGRATION
+@property (weak, nonatomic) id<APDRewardedVideoRequestDelegate> requestDelegate;
+#endif
 
 /*!
  *  Set delegate to skippable video
@@ -96,22 +104,27 @@
 @property (weak, nonatomic) id<APDRewardedVideoDelegate> delegate;
 
 /*!
- *  Set custom placement name, that you create in Appodeal Dashbord
+ *  Return reward object currencyName as NSString, and amount as NSUInteger
+ */
+@property (strong, nonatomic, readonly) id<APDReward> reward;
+
+/*!
+ *  Set custom placement name, that you create in the Appodeal Dashboard
  */
 @property (copy, nonatomic) NSString *placement;
 
 /*!
- *  Set custom sdk
+ *  Set custom SDK
  */
 @property (weak, nonatomic) APDSdk *customSdk;
 
 /*!
- *  Getter rewarded video availability
+ *  Get rewarded video availability
  */
 @property (assign, nonatomic, readonly, getter=isReady) BOOL ready;
 
 /*!
- *  Start rewarded video loading
+ *  Start loading rewarded video
  */
 - (void)loadAd;
 

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDSdk.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDSdk.h
@@ -2,7 +2,9 @@
 //  APDSdk.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -10,22 +12,22 @@
 #import <Appodeal/APDDefines.h>
 
 /*!
- * Main sdk object, that managed network request, ad modules and statistics data.
- * You should initilize sdk before you start loading any ad types.
- * You can do this in 
- * @discussion - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions 
+ * Main SDK object, that managed network request, ad modules and statistics data.
+ * You should initialize the SDK before you start loading any ad types.
+ * You can do this in
+ * @discussion - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
  * @discussion for example.
- * @warning You must call sharedSdkWithApiKey:(NSString *)apiKey firstly. 
- * @discussion For example initializiton code can be something like this:
- * @code 
- - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [[APDSdk sharedSdkWithApiKey: YOUR_API_KEY] initializeForAdTypes: APDAdTypeInterstitialAd];
- return YES;
- }
+ * @warning You must call sharedSdkWithApiKey:(NSString *)apiKey firstly.
+ * @discussion For example initialization code can be something like this:
+ * @code
+    - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+        [[APDSdk sharedSdkWithApiKey: YOUR_API_KEY] initializeForAdTypes: APDAdTypeInterstitialAd];
+        return YES;
+    }
  * @endcode
-
- * After sdk initialization you can get instanse of sdk by calle [APDSdk sharedSdk];
- * You can additional set other sdk settings before/after sdk initialization
+ 
+ * After SDK initialization, you can get an instance of SDK by calling [APDSdk sharedSdk];
+ * You can additionally set other SDK settings before/after SDK initialization
  */
 @interface APDSdk : NSObject
 
@@ -44,12 +46,12 @@
 + (instancetype)new NS_UNAVAILABLE;
 
 /*!
- *  @brief Singleton instance of APDSdk
+ *  Singleton instance of APDSdk
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [APDSdk sharedSdkWithApiKey:@"API_KEY"]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code APDSdk.sharedSdkWithApiKey("API_KEY") @endcode
  *
  *  @param apiKey String API key parameter from Appodeal Dashboard
@@ -60,12 +62,12 @@
 
 
 /*!
- *  @brief Always returns same instance SDK returned by first call of +sharedSdkWithApiKey:
+ *  Always returns same instance SDK returned by first call of +sharedSdkWithApiKey:
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [APDSdk sharedSdk]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code APDSdk.sharedSdk() @endcode
  *
  *  @return Instance of APDSdk
@@ -73,12 +75,12 @@
 + (instancetype)sharedSdk;
 
 /*!
- *  @brief Call this method to specify framework before initialization
+ *  Call this method to specify framework before initialization
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [[APDSdk sharedSdk] setFramework:APDFrameworkNative]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code APDSdk.sharedSdk().setFramework(APDFramework.native) @endcode
  *
  *  @param framework Type of framework. Default is native iOS SDK
@@ -86,43 +88,50 @@
 - (void)setFramework:(APDFramework)framework;
 
 /*!
- *  @brief Initializtion of sdk for types
+ *  Call this method to specify framework before initialization
  *
- *  @brief Objective-C
- *  @code [[APDSdk sharedSdk] initializeForAdTypes:AppodealAdTypeInterstitial | AppodealAdTypeRewardedVideo]; @endcode
- *
- *  @brief Swift
- *  @code 
-    let adTypes: AppodealAdType = [.banner, .interstitial]
-    APDSdk.sharedSdk().initializeForAdTypes(adTypes) @endcode
- *
- *  @param adTypes APDAdTypeInterstitialAd, APDAdTypeSkippableVideo, APDAdTypeBanner, APDAdTypeNativeAd, APDAdTypeRewardedVideo, APDAdTypeMREC
+ *  @param pluginVersion - NSString version plugin
  */
-- (void)initializeForAdTypes:(APDAdType)adTypes;
+- (void)setPluginVersion:(NSString *)pluginVersion;
 
 /*!
- *  @brief Check that sdk is initialized for ad type
+ *  Initialization of SDK for types
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
+ *  @code [[APDSdk sharedSdk] initializeForAdTypes:AppodealAdTypeInterstitial | AppodealAdTypeRewardedVideo]; @endcode
+ *
+ *  @discussion Swift
+ *  @code
+ let adTypes: AppodealAdType = [.banner, .interstitial]
+ APDSdk.sharedSdk().initializeForAdTypes(adTypes) @endcode
+ *
+ *  @param adTypes APDAdTypeInterstitialAd, APDAdTypeBanner, APDAdTypeNativeAd, APDAdTypeRewardedVideo, APDAdTypeMREC
+ */
+- (void)initializeForAdTypes:(APDType)adTypes;
+
+/*!
+ *  Check that SDK is initialized for ad type
+ *
+ *  @discussion Objective-C
  *  @code [[APDSdk sharedSdk] isInitializedForAdType:AppodealAdTypeInterstitial]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code APDSdk.sharedSdk().isInitializedForAdType(APDAdType.interstitial) @endcode
  *
  *  @param adType APDAdType value
  *
- *  @return YES if sdk initialized for this type, or NO if not
+ *  @return YES if SDK initialized for this type, or NO if not
  */
-- (BOOL)isInitializedForAdType:(APDAdType)adType;
+- (BOOL)isInitializedForAdType:(APDType)adType;
 
 /*!
- *  @brief If you set YES to this method you get only
- *  test ad with 0$ eCPM
- *
- *  @brief Objective-C
+ *  If you set YES for this method you get only
+ *  test ad with $0 eCPM
+ *  @warning use this method before initilized sdk
+ *  @discussion Objective-C
  *  @code [[APDSdk sharedSdk] setTesingMode:YES]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code APDSdk.sharedSdk().setTesingMode(true) @endcode
  *
  *  @param enabled Boolean flag
@@ -130,34 +139,34 @@
 - (void)setTesingMode:(BOOL)enabled;
 
 /*!
- *  @brief Set targeting for more satisfying ads
+ *  Set targeting for more relevant ads
  *
- *  @brief Objective-C
- *  @code 
-    APDUserInfo * userInfo = [APDUserInfo new];
-    userInfo.age = 25;
-    [[APDSdk sharedSdk] setUserInfo:userInfo];
+ *  @discussion Objective-C
+ *  @code
+        APDUserInfo * userInfo = [APDUserInfo new];
+        userInfo.age = 25;
+        [[APDSdk sharedSdk] setUserInfo:userInfo];
  *  @endcode
  *
- *  @brief Swift
- *  @code 
-    let userInfo = APDUserInfo()
-    userInfo.age = 25
-    APDSdk.sharedSdk().setUserInfo(userInfo) 
+ *  @discussion Swift
+ *  @code
+        let userInfo = APDUserInfo()
+        userInfo.age = 25
+        APDSdk.sharedSdk().setUserInfo(userInfo)
  *  @endcode
  *
- *  @param userInfo Insatance of APDUserInfo class
+ *  @param userInfo Instance of APDUserInfo class
  */
 - (void)setUserInfo:(APDUserInfo *)userInfo;
 
 /*!
- *  @brief If you does not want to some ad network
- *  @brief get user info call this method
+ *  If you do not want some ad network to
+ *  get user info call this method
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [[APDSdk sharedSdk] disableUserInfoForNetworkName:@"NETWORK_NAME"]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code APDSdk.sharedSdk().disableUserInfoForNetworkName("NETWORK_NAME") @endcode
  *
  *  @param networkName Appodeal ad network name for example: @"mopub", @"admob"
@@ -165,48 +174,63 @@
 - (void)disableUserInfoForNetworkName:(NSString *)networkName;
 
 /*!
- *  @brief You can set custom rule by usage this method.
+ *  You can set custom rules by using this method.
  *  Configure rules for segments in <b>Appodeal Dashboard</b>.
- *  @discussion For example, you want to use segment, when user complete 20 or more levels
- *  You create rule in dashboard with name "completedLevels" of type Int,
- *  operator GreaterThanOrEqualTo and value 10, now you implement folowing code:
+ *  @discussion For example, if you want to create a segment of users who complete 20 or more levels,
+ *  you create a rule in the dashboard with name "completedLevels" of type Int,
+ *  operator GreaterThanOrEqualTo and value 10, now you implement following code:
  *
- *  @brief Objective-C
- *  @code 
-    NSDictionary * customRule = {@"completedLevels" : CURRENT_NUMBER_OF_COMPLETED_LEVELS};
-    [[APDSdk sharedSdk] setCustomRule: customRule];
+ *  @discussion Objective-C
+ *  @code
+        NSDictionary * customRule = {@"completedLevels" : CURRENT_NUMBER_OF_COMPLETED_LEVELS};
+        [[APDSdk sharedSdk] setCustomRule: customRule];
  *  @endcode
  *
- *  @brief Swift
- *  And then CURRENT_NUMBER_OF_COMPLETED_LEVELS become 10 or greater
- *  You segments settings become available
+ *  @discussion Swift
+ *  And then CURRENT_NUMBER_OF_COMPLETED_LEVELS becomes 10 or greater
+ *  Your segments settings become available
  *
- *  @param customRule NSDictionary instance with keys that similar to  keys that you tune in Appodeal Dashboard's Segment settings block and values of similar types
+ *  @param customRule NSDictionary instance with keys that are similar to  keys that you turn on in Appodeal Dashboard's Segment settings block and values of similar types
  */
+
 - (void)setCustomRule:(NSDictionary *)customRule;
 
 
 /*!
  *  Appodeal SDK supports multiple log level for internal logging,
  *  and ONLY one (VERBOSE) log level for third party ad networks.
- *  To enable third party ad networks logging set log level to APDLogLevelVerbose.
- *  If log level other than APDLogLevelVerbose, all third party ad networks logging will be suppressed (if possible).
+ *  To enable third party ad networks logging, set log level to APDLogLevelVerbose.
+ *  If the log level is something other than APDLogLevelVerbose, all third party ad networks logging will be suppressed (if possible).
  *
  *  @param logLevel APDLogLevel value
  */
 - (void)setLogLevel:(APDLogLevel)logLevel;
 
 /*!
- *  Disabling/enabling loction tracking
+ *  Disabling/enabling location tracking
  *
- *  @param enabled By default set to NO
+ *  @param enabled Set to NO by default
  */
 - (void)setLocationTracking:(BOOL)enabled;
 
 /*!
- *  @brief Reset UUID for tracking/targeting ad
+ *  Reset UUID for tracking/targeting ads
  */
 - (void)resetUUID;
+
+/*!
+ *  Enable memory monitoring for ad type. If current memory consumption is higher than required, all cached ad objects will be released
+ *  @warning loaded ad will return and will not be shown
+ *
+ *  @param percentage Minimum percent of RAM free is from 1 to 100. If NSNotFound memory monitor is inactive
+ *  @param observeSystemWarnings enable system warnings observation
+ *  @param type Type of ad to use
+ */
+- (void)setMinimumFreeMemoryPercentage:(NSUInteger)percentage
+                 observeSystemWarnings:(BOOL)observeSystemWarnings
+                             forAdType:(APDType)type;
+
+- (void)setChildDirectedTreatment:(BOOL)childDirectedTreatment;
 
 @end
 
@@ -215,7 +239,7 @@
 
 /*!
  *  In-app purchase tracking.
- *  Call this method after user make some in-app purchase
+ *  Call this method after user makes an in-app purchase
  *
  *  @param amount   Amount of in-app purchase, for example @0.99
  *  @param currency In-app purchase currency, for example @"USD"

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDSkippableVideo.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDSkippableVideo.h
@@ -2,7 +2,9 @@
 //  APDSkippableVideo.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -21,55 +23,55 @@
 @optional
 
 /*!
- *  Method called when skippable video did load
+ *  Method called when skippable video loads
  *
  *  @param skippableVideo Ready to show skippable video
  */
 - (void)skippableVideoDidLoad:(APDSkippableVideo *)skippableVideo;
 
 /*!
- *  Method called if skippable video mediation was failed
+ *  Method called if skippable video mediation failed
  *
  *  @param skippableVideo Failed skippable video
  */
 - (void)skippableVideo:(APDSkippableVideo *)skippableVideo didFailToLoadWithError:(NSError *)error;
 
 /*!
- *  Method called if skippable video adapter become unavailable
- *  This case can occure only for singleton ad networks: AdColony, Vungle, Unity
+ *  Method called if skippable video adapter becomes unavailable
+ *  This case can occur only for singleton ad networks: AdColony, Vungle, Unity
  *
  *  @param skippableVideo Failed skippable video
  */
 - (void)skippableVideoDidBecomeUnavailable:(APDSkippableVideo *)skippableVideo;
 
 /*!
- *  Method called after skippable video did show
+ *  Method called after skippable video shows
  *
  *  @param skippableVideo Shown skippable video
  */
 - (void)skippableVideoDidAppear:(APDSkippableVideo *)skippableVideo;
 
 /*!
- *  Method called after skippable video did finish
- *  @warning Not all video ad networks provides this callback
- *  therefore this callback may not called even video was fully watched
+ *  Method called after skippable video completed
+ *  @warning Not all video ad networks provide this callback,
+ *  therefore this callback may not be called even if the video was  completed
  *
  *  @param skippableVideo Shown skippable video
  */
 - (void)skippableVideoDidFinish:(APDSkippableVideo *)skippableVideo;
 
 /*!
- *  Method called after skippable video did dismiss from screen
+ *  Method called after skippable video is dismissed from screen
  *
  *  @param skippableVideo Shown skippable video
  */
 - (void)skippableVideoDidDisappear:(APDSkippableVideo *)skippableVideo;
 
 /*!
- *  Method called if skippable video adapter occure some error while presenting
+ *  Method called if error occurs while presenting skippable video adapter
  *
  *  @param skippableVideo Failed skippable video
- *  @param error          Occured error
+ *  @param error          Error occurred
  */
 - (void)skippableVideo:(APDSkippableVideo *)skippableVideo didFailToPresentWithError:(NSError *)error;
 
@@ -77,14 +79,14 @@
 
 
 /*!
- *  You should have strong refrence on loading skippable video instance
+ *  You should have strong reference on loading skippable video instance
  *  Instance of skippable video ad can try to load ad only once!
  *  Create new skippable video before any call -loadAd!
  *  @code - (void) loadSkippableVideo {
-    self.skippableVideo = [APDSkippableVideo new];
-    self.skippableVideo.delegate = self;
-    [self.skippableVideo loadAd]
- }
+            self.skippableVideo = [APDSkippableVideo new];
+            self.skippableVideo.delegate = self;
+            [self.skippableVideo loadAd]
+        }
  */
 @interface APDSkippableVideo : NSObject
 
@@ -94,30 +96,30 @@
 @property (weak, nonatomic) id<APDSkippableVideoDelegate> delegate;
 
 /*!
- *  Set custom placement name, that you create in Appodeal Dashbord
+ *  Set custom placement name, that you create in Appodeal Dashboard
  */
 @property (copy, nonatomic) NSString *placement;
 
 /*!
- *  Set custom sdk
+ *  Set custom SDK
  */
 @property (weak, nonatomic) APDSdk *customSdk;
 
 /*!
- *  Getter skippable video availability
+ *  Get skippable video availability
  */
 @property (assign, nonatomic, readonly, getter=isReady) BOOL ready;
 
 /*!
- *  Start skippable video loading
+ *  Start loading skippable video
  */
-- (void)loadAd;
+- (void)loadAd __attribute__((deprecated("As of version 1.4.0 skippable video contains in interstitial ad")));
 
 /*!
  *  Show ready skippable video from view controller
  *
  *  @param viewController Current presented view controller
  */
-- (void)presentFromViewController:(UIViewController *)viewController;
+- (void)presentFromViewController:(UIViewController *)viewController __attribute__((deprecated("As of version 1.4.0 skippable video contains in interstitial ad")));
 
 @end

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDUserInfo.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDUserInfo.h
@@ -2,7 +2,9 @@
 //  APDUserInfo.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -20,12 +22,12 @@
 @property (copy, nonatomic) NSString *email;
 
 /**
- *  Set user id
+ *  Set user ID
  */
 @property (copy, nonatomic) NSString *userId;
 
 /**
- *  Array of user intersets in string
+ *  Array of user interests in string
  * @code userInfo.interests = @[@"music", @"sport"];
  */
 @property (copy, nonatomic) NSArray *interests;

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDUserInfoProtocol.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/APDUserInfoProtocol.h
@@ -2,7 +2,9 @@
 //  APDUserInfoProtocol.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 
@@ -17,6 +19,7 @@
 @property (copy, nonatomic, readonly) NSDictionary *ext;
 
 @property (strong, nonatomic, readonly) NSDate *birthday;
+@property (strong, nonatomic, readonly) NSString *birthdayString;
 @property (assign, nonatomic, readonly) NSUInteger age;
 @property (assign, nonatomic, readonly) APDUserGender gender;
 @property (assign, nonatomic, readonly) APDUserOccupation occupation;

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/Appodeal.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/Appodeal.h
@@ -2,8 +2,13 @@
 //  Appodeal.h
 //  Appodeal
 //
-//  Copyright (c) 2015 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
 //
+//  Copyright (c) 2017 Appodeal, Inc. All rights reserved.
+//
+
+
+#define ADVANCED_INTEGRATION 1
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
@@ -21,346 +26,16 @@
 #import <Appodeal/APDBannerView.h>
 
 #import <Appodeal/APDNativeAdLoader.h>
+#import <Appodeal/APDNativeAdQueue.h>
 #import <Appodeal/APDNativeAd.h>
 #import <Appodeal/APDImage.h>
 #import <Appodeal/APDMediaView.h>
 
-
-FOUNDATION_EXPORT const CGSize kAppodealUnitSize_320x50;
-FOUNDATION_EXPORT const CGSize kAppodealUnitSize_300x250;
-FOUNDATION_EXPORT const CGSize kAppodealUnitSize_728x90;
-
-FOUNDATION_EXPORT NSArray * AppodealAvailableUnitSizes();
-
-FOUNDATION_EXPORT BOOL AppodealIsUnitSizeSupported(const CGSize size, NSArray *supportedSizes);
-FOUNDATION_EXPORT BOOL AppodealIsUnitSizeAvailable(const CGSize size);
-
-
-FOUNDATION_EXPORT CGSize AppodealNearestUnitSizeForSize(CGSize size);
-
+#ifdef ADVANCED_INTEGRATION
+#import <Appodeal/AppodealRequestDelegateProtocol.h>
+#endif
 /*!
- *  Appodeal ads types
- */
-typedef NS_OPTIONS(NSInteger, AppodealAdType) {
-    /*!
-     *  Interstitial
-     */
-    AppodealAdTypeInterstitial      = 1 << 0,
-    /*!
-     *  Skippable video (can be skipped by user after several seconds of watch)
-     */
-    AppodealAdTypeSkippableVideo    = 1 << 1,
-    /*!
-     *  Banner ads
-     */
-    AppodealAdTypeBanner            = 1 << 2,
-    /*!
-     *  Native ads
-     */
-    AppodealAdTypeNativeAd          = 1 << 3,
-    /*!
-     *  Rewarded video (return reward parameter in finish callback, can not be skipped by user)
-     */
-    AppodealAdTypeRewardedVideo     = 1 << 4,
-    /*!
-     *  Rectangle banner of size 300 x 250
-     */
-    AppodealAdTypeMREC              = 1 << 5,
-    /*!
-     *  Non skippable video (does not return reward parameter in finish callback, can not be skipped by user)
-     */
-    AppodealAdTypeNonSkippableVideo = 1 << 6,
-};
-
-/*!
- *  Appodeal styles to show
- */
-typedef NS_ENUM(NSInteger, AppodealShowStyle) {
-    /*!
-     *  Show interstial ads
-     */
-    AppodealShowStyleInterstitial = 1,
-    /*!
-     *  Show skippable ads
-     */
-    AppodealShowStyleSkippableVideo,
-    /*!
-     *  - If both ready, show ad that eCPM heigher
-     *  @discussion - If one of this types ready, show with ad
-     *  @discussion - If no one ready, waiting for first ready
-     */
-    AppodealShowStyleVideoOrInterstitial __attribute__((deprecated("This style will be removed in next release!"))),
-    /*!
-     *  Show banner at top of screen
-     */
-    AppodealShowStyleBannerTop,
-    /*!
-     *  Show banner at bottom of screen
-     */
-    AppodealShowStyleBannerBottom,
-    /*!
-     *  Show rewareded video
-     */
-    AppodealShowStyleRewardedVideo,
-    /*!
-     *  Show non skippable video
-     */
-    AppodealShowStyleNonSkippableVideo
-};
-
-typedef NS_ENUM(NSUInteger, AppodealUserGender) {
-    AppodealUserGenderOther = 0,
-    AppodealUserGenderFemale,
-    AppodealUserGenderMale
-};
-
-typedef NS_ENUM(NSUInteger, AppodealUserOccupation) {
-    AppodealUserOccupationOther = 0,
-    AppodealUserOccupationWork,
-    AppodealUserOccupationSchool,
-    AppodealUserOccupationUniversity
-};
-
-typedef NS_ENUM(NSUInteger, AppodealUserRelationship) {
-    AppodealUserRelationshipOther = 0,
-    AppodealUserRelationshipSingle,
-    AppodealUserRelationshipDating,
-    AppodealUserRelationshipEngaged,
-    AppodealUserRelationshipMarried,
-    AppodealUserRelationshipSearching
-};
-
-typedef NS_ENUM(NSUInteger, AppodealUserSmokingAttitude) {
-    AppodealUserSmokingAttitudeNegative = 1,
-    AppodealUserSmokingAttitudeNeutral,
-    AppodealUserSmokingAttitudePositive
-};
-
-typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
-    AppodealUserAlcoholAttitudeNegative = 1,
-    AppodealUserAlcoholAttitudeNeutral,
-    AppodealUserAlcoholAttitudePositive
-};
-
-/*!
- *  Declaration of banner delegate
- */
-@protocol AppodealBannerDelegate <NSObject>
-
-@optional
-/*!
- *  Method called when precache (cheap and fast load) or usual banner view did load
- *
- *  @param precache If precache is YES it's mean that precache loaded
- */
-- (void)bannerDidLoadAdIsPrecache:(BOOL)precache;
-
-/*!
- *  @brief Method called when banner did load and ready to show
- */
-- (void)bannerDidLoadAd __attribute__((deprecated("Use -bannerDidLoadAdisPrecache:precache: instead")));
-
-/*!
- *  Method called when banner refresh
- */
-- (void)bannerDidRefresh;
-
-/*!
- *  Method called if banner mediation failed
- */
-- (void)bannerDidFailToLoadAd;
-
-/*!
- *  Method called when user tap on banner
- */
-- (void)bannerDidClick;
-
-/*!
- *  Method called when banner show first time
- *  @warniing After refresh this method not called
- */
-- (void)bannerDidShow;
-
-@end
-
-/*!
- *  Interstital delegate declaration
- */
-@protocol AppodealInterstitialDelegate <NSObject>
-
-@optional
-
-/*!
- *  Method called when usual interstitial view did load
- *
- */
-- (void)interstitialDidLoadAd __attribute__((deprecated("Use -interstitialDidLoadAdisPrecache: instead")));
-
-/*!
- *  Method called when precache (cheap and fast load) or usual interstitial view did load
- *  @warning If you want show only expensive ad, ignore this callback call with precache equal to YES
- *
- *  @param precache If precache is YES it's mean that precache loaded
- */
-- (void)interstitialDidLoadAdisPrecache:(BOOL)precache;
-
-/*!
- *  Nethod called if interstitial mediation failed
- */
-- (void)interstitialDidFailToLoadAd;
-
-/*!
- *  Method called when interstitial will diaplay on screen
- */
-- (void)interstitialWillPresent;
-
-/*!
- *  Method called after interstitial leave screeen
- */
-- (void)interstitialDidDismiss;
-
-/*!
- *  Method called when user tap on interstitial
- */
-- (void)interstitialDidClick;
-
-@end
-
-
-/*!
- *  Rewarded video delegate declaration
- */
-@protocol AppodealRewardedVideoDelegate <NSObject>
-
-@optional
-
-/*!
- *  Method called when rewarded video did load
- */
-- (void)rewardedVideoDidLoadAd;
-
-/*!
- *  Mehtod called if rewarded video mediation failed
- */
-- (void)rewardedVideoDidFailToLoadAd;
-
-/*!
- *  Method called after rewarded video start displaying
- */
-- (void)rewardedVideoDidPresent;
-
-/*!
- *  Methof called before rewarded video leave screen
- */
-- (void)rewardedVideoWillDismiss;
-
-/*!
- *  Method called after fully watch of video
- *  @warning After call this method rewarded video can stay on screen and show postbanner
- *
- *  @param rewardAmount Amount of app curency tuned via Appodeal Dashboard
- *  @param rewardName   Name of app curency tuned via Appodeal Dashboard
- */
-- (void)rewardedVideoDidFinish:(NSUInteger)rewardAmount name:(NSString *)rewardName;
-
-/*!
- *  Method called after user tap on screen
- *  @warning Not all ad networks provides this callback!
- */
-- (void)rewardedVideoDidClick;
-
-@end
-
-
-/*!
- *  Non skippable video delegate
- */
-@protocol AppodealNonSkippableVideoDelegate <NSObject>
-
-@optional
-
-/*!
- *  Method called when non skippable video did load
- */
-- (void)nonSkippableVideoDidLoadAd;
-
-/*!
- *  Mehtod called if non skippable video mediation failed
- */
-- (void)nonSkippableVideoDidFailToLoadAd;
-
-/*!
- *  Method called after non skippable video start displaying
- */
-- (void)nonSkippableVideoDidPresent;
-
-/*!
- *  Methof called before non skippable video leave screen
- */
-- (void)nonSkippableVideoWillDismiss;
-
-/*!
- *  Method called after fully watch of video
- *  @warning After call this method non skippable video can stay on screen and show postbanner
- *
-*/
-- (void)nonSkippableVideoDidFinish;
-
-/*!
- *  Method called after user tap on screen
- *  @warning Not all ad networks provides this callback!
- */
-- (void)nonSkippableVideoDidClick;
-
-@end
-
-
-/*!
- *  Skippable video delegate
- */
-@protocol AppodealSkippableVideoDelegate <NSObject>
-
-@optional
-
-/*!
- *  Method called when skippable video did load
- */
-- (void)skippableVideoDidLoadAd;
-
-/*!
- *  Mehtod called if skippable video mediation failed
- */
-- (void)skippableVideoDidFailToLoadAd;
-
-/*!
- *  Method called after skippable video start displaying
- */
-- (void)skippableVideoDidPresent;
-
-/*!
- *  Methof called before skippable video leave screen
- */
-- (void)skippableVideoWillDismiss;
-
-/*!
- *  Method called after fully watch of video, if user skipp video this callback not called
- *  @warning After call this method skippable video can stay on screen and show postbanner
- *  @warning Not all ad networks provides this callback!
- *
- */
-- (void)skippableVideoDidFinish;
-
-/*!
- *  Method called after user tap on screen
- *  @warning Not all ad networks provides this callback!
- */
-- (void)skippableVideoDidClick;
-
-@end
-
-
-/*!
- *  Appdoeal ads sdk
+ *  Appdoeal ads SDK
  */
 @interface Appodeal : NSObject
 
@@ -369,48 +44,48 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (instancetype)new NS_UNAVAILABLE;
 
 /*!
- *  @brief To disable network use this method
- *  @brief Use method before initializtion!
- *  @brief Objective-C
+ *  To disable a network use this method
+ *  @warning Use method before initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal disableNetworkForAdType:AppodealAdTypeInterstitial name:@"YOUR_NETWORK_NAME"]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.disableNetworkForAdType(AppodealAdType.Interstitial, name: "YOUR") @endcode
- *  @param adType      AppodealAdTypeInterstitial, AppodealAdTypeSkippableVideo, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
+ *  @param adType      AppodealAdTypeInterstitial, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
  *  @param networkName Use network name
  */
-+ (void)disableNetworkForAdType:(AppodealAdType)adType name:(NSString *)networkName __attribute__((deprecated("Now you can simple delete unused adapter from project")));
++ (void)disableNetworkForAdType:(AppodealAdType)adType name:(NSString *)networkName __attribute__((deprecated("Now you can delete network in segments settings on Appodeal Dashboard")));
 
 /*!
- *  @brief To disable location check use this method (deprecated), use setLocationTracking:
- *  @brief Objective-C
+ *  @discussion To disable location check, use this method (deprecated), use setLocationTracking:
+ *  @discussion Objective-C
  *  @code [Appodeal disableLocationPermissionCheck]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.disableLocationPermissionCheck() @endcode
  */
 + (void)disableLocationPermissionCheck __attribute__((deprecated("use method setLocationTracking:")));
 
 /*!
- *  @brief To disable location check use this method
- *  @brief Use method before initializtion!
- *  @brief Objective-C
+ *  @discussion To disable location check, use this method
+ *  @discussion Use method before initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal setLocationTracking:YES]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setLocationTracking(true) @endcode
  *  @param enabled Set flag NO if you have disabled locationTracking, and YES that enabled
  */
 + (void)setLocationTracking:(BOOL)enabled;
 
 /*!
- *  @brief Enable/disable autocache
- *  @brief Use method before initializtion!
- *  @discussion After initialization sdk start cache ads of those types that was enable as autocache
+ *  @discussion Enable/disable autocache
+ *  @discussion Use method before initialization!
+ *  @discussion After initializing the SDK, start caching ads of those types that were enabled as autocache
  *  Default autocache enabled for AppodealAdTypeInterstitial, AppodealAdTypeRewardedVideo or AppodealAdTypeNonSkippableVideo
  *  Also you can do something like this to disable autocache:
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code
-    [Appodeal setAutocache: NO types: AppodealAdTypeInterstitial | AppodealAdTypeRewardedVideo]
+        [Appodeal setAutocache: NO types: AppodealAdTypeInterstitial | AppodealAdTypeRewardedVideo]
  *  @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setAutocache(false, types: AppodealAdType.Interstitial) @endcode
  *  @param autocache Bolean flag
  *  @param types     AppodealAdTypeRewardedVideo or AppodealAdTypeNonSkippableVideo, AppodealAdTypeInterstitial, AppodealAdTypeSkippableVideo
@@ -418,11 +93,11 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setAutocache:(BOOL)autocache types:(AppodealAdType)types;
 
 /*!
- *  @brief Getter of autocache enabling
- *  @brief after initializtion!
- *  @brief Objective-C
+ *  @discussion Get autocache enablement
+ *  @discussion after initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal isAutocacheEnabled:AppodealAdTypeInterstitial]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.isAutocacheEnabled(AppodealAdType.Interstitial) @endcode
  *  @param types AppodealAdTypeRewardedVideo, AppodealAdTypeInterstitial, AppodealAdTypeSkippableVideo
  *
@@ -431,14 +106,14 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (BOOL)isAutocacheEnabled:(AppodealAdType)types;
 
 /*!
- *  @brief Initialize method. To initialize appodeal with several types you
- *  @brief can do something like this:
- *  @brief Objective-C
+ *  @discussion Initialize method. To initialize Appodeal with several types you
+ *  @discussion can do something like this:
+ *  @discussion Objective-C
  *  @code [Appodeal initializeWithApiKey:YOUR_API_KEY types: AppodealAdTypeInterstitial | AppodealAdTypeRewardedVideo]; @endcode
- *  @brief Swift
- *  @code 
-    let adTypes: AppodealAdType = [.banner, .interstitial]
-    Appodeal.initialize(withApiKey: "API_KEY", types: adTypes) @endcode
+ *  @discussion Swift
+ *  @code
+        let adTypes: AppodealAdType = [.banner, .interstitial]
+        Appodeal.initialize(withApiKey: "API_KEY", types: adTypes) @endcode
  *  @param apiKey Your api key from Appodeal Dashboard
  *  @param types  Appodeal ad type
  */
@@ -447,90 +122,125 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)deinitialize NS_UNAVAILABLE;
 
 /*!
- *  @brief Getter that sdk initialized
- *  @brief Use method after initializtion!
- *  @brief Objective-C
+ *  @discussion Get that SDK initialized
+ *  @discussion Use method after initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal isInitalized]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.isInitalized() @endcode
  *  @return YES if sdk initialized or NO if not
  */
 + (BOOL)isInitalized;
 
 /*!
- *  @brief Set framework type before initializtion!
- *  @brief Objective-C
+ *  Appodeal supports multiple log levels for internal logging,
+ *  and ONLY one (VERBOSE) log level for third party ad networks.
+ *  To enable third party ad networks logging, set log level to APDLogLevelVerbose.
+ *  If log level other than APDLogLevelVerbose, all third party ad networks logging will be suppressed (if possible).
+ *
+ *  @param logLevel APDLogLevel value
+ */
++ (void)setLogLevel:(APDLogLevel)logLevel;
+
+/*!
+ *  @discussion Set framework type before initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal setFramework:APDFrameworkNative]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setFramework(APDFramework.native) @endcode
  *  @param framework Framework type, default is iOS Native SDK
  */
 + (void)setFramework:(APDFramework)framework;
 
 /*!
- *  @brief Set interstital delegate to get callbacks
- *  @brief Use method before or after initializtion!
- *  @brief Objective-C
+ *  @discussion Set plugin version use before initialization!
+ *  @discussion Objective-C
+ *  @code [Appodeal setPluginVersion:@"1.0.0"]; @endcode
+ *  @discussion Swift
+ *  @code Appodeal.setPluginVersion("1.0.0") @endcode
+ *  @param pluginVersion -  NSString value, default nil
+ */
++ (void)setPluginVersion:(NSString *)pluginVersion;
+
+/*!
+ *  @discussion Set interstitial delegate to get callbacks
+ *  @discussion Use method before or after initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal setInterstitialDelegate:self]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setInterstitialDelegate(self) @endcode
  *  @param interstitialDelegate Object that implement AppodealInterstitialDelegate protocol
  */
 + (void)setInterstitialDelegate:(id<AppodealInterstitialDelegate>)interstitialDelegate;
 
 /*!
- *  @brief Set banner delegate to get callbacks
- *  @brief Use method before or after initializtion!
- *  @brief Objective-C
+ *  @discussion Set banner delegate to get callbacks
+ *  @discussion Use method before or after initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal setBannerDelegate:self]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setBannerDelegate(self) @endcode
- *  @param bannerDelegate Object that implement AppodealBannerDelegate protocol
+ *  @param bannerDelegate Object that implements AppodealBannerDelegate protocol
  */
 + (void)setBannerDelegate:(id<AppodealBannerDelegate>)bannerDelegate;
 
 /*!
- *  @brief Set skippable video delegate to get callbacks
- *  @brief Use method before or after initializtion!
- *  @brief Objective-C
+ *  @discussion Set skippable video delegate to get callbacks
+ *  @discussion Use method before or after initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal setSkippableVideoDelegate:self]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setSkippableVideoDelegate(self) @endcode
- *  @param videoDelegate Object that implement AppodealSkippableVideoDelegate protocol
+ *  @param videoDelegate Object that implements AppodealSkippableVideoDelegate protocol
  */
-+ (void)setSkippableVideoDelegate:(id<AppodealSkippableVideoDelegate>)videoDelegate;
++ (void)setSkippableVideoDelegate:(id<AppodealSkippableVideoDelegate>)videoDelegate __attribute__((deprecated("use Interstitial")));
 
 /*!
- *  @brief Set rewarded video delegate to get callbacks
- *  @brief Use method before or after initializtion!
- *  @brief Objective-C
+ *  @discussion Set rewarded video delegate to get callbacks
+ *  @discussion Use method before or after initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal setRewardedVideoDelegate:self]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setRewardedVideoDelegate(self) @endcode
- *  @param rewardedVideoDelegate Object that implement AppodealRewardedVideoDelegate protocol
+ *  @param rewardedVideoDelegate Object that implements AppodealRewardedVideoDelegate protocol
  */
 + (void)setRewardedVideoDelegate:(id<AppodealRewardedVideoDelegate>)rewardedVideoDelegate;
 
 /*!
- *  @brief Set non skippable video delegate to get callbacks
- *  @brief Use method before or after initializtion!
- *  @brief Objective-C
+ *  @discussion Set non skippable video delegate to get callbacks
+ *  @discussion Use method before or after initialization!
+ *  @discussion Objective-C
  *  @code [Appodeal setNonSkippableVideoDelegate:self]; @endcode
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setNonSkippableVideoDelegate(self) @endcode
- *  @param nonSkippableVideoDelegate Object that implement AppodealNonSkippableVideoDelegate protocol
+ *  @param nonSkippableVideoDelegate Object that implements AppodealNonSkippableVideoDelegate protocol
  */
 + (void)setNonSkippableVideoDelegate:(id<AppodealNonSkippableVideoDelegate>)nonSkippableVideoDelegate;
 
 /*!
- *  @brief Appodeal banner view to custom placement
- *  @brief Use method before or after initializtion!
+ *  @discussion Set native ad delegate to get callbacks
+ *  @discussion Use method before or after initialization!
+ *  @discussion Objective-C
+ *  @code [Appodeal setNativeAdDelegate:self]; @endcode
+ *  @discussion Swift
+ *  @code Appodeal.setNativeAdDelegate(self) @endcode
+ *  @param nativeAdDelegate Object that implements AppodealNonSkippableVideoDelegate protocol
+ */
++ (void)setNativeAdDelegate:(id<AppodealNativeAdDelegate>)nativeAdDelegate;
+
+#ifdef ADVANCED_INTEGRATION
++ (void)setRequestDelegate:(id<AppodealRequestDelegate>)requestDelegate;
+#endif
+
+/*!
+ *  @discussion Appodeal banner view to custom placement
+ *  @discussion Use method before or after initialization!
  *  @warning We highly recommend to use APDSdk and APDBannerView if you want to get custom placement of banner ads in your app
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal banner]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.banner() @endcode
  *
  *  @return View that contains banner ad
@@ -538,12 +248,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (UIView *)banner;
 
 /*!
- *  @brief If ad of this type ready, ad show at once. But if not ad start caching and show after caching anyway if it have time to 3 seconds.
+ *  @discussion If an ad of this type is ready, the ad shows at once. But if not, an ad starts caching and shows after caching, if it has time to within 3 seconds.
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal showAd:AppodealAdTypeInterstitial rootViewController:UIViewController]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.showAd(AppodealShowStyle.Interstitial, rootViewController: UIViewController!) @endcode
  *
  *  @param style              AppodealAdTypeInterstitial, AppodealAdTypeSkippableVideo, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
@@ -554,12 +264,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (BOOL)showAd:(AppodealShowStyle)style rootViewController:(UIViewController *)rootViewController;
 
 /*!
- *  @brief - @sa + (BOOL)showAd:(AppodealShowStyle)style rootViewController:(UIViewController *)rootViewController;
+ *  @discussion - @sa + (BOOL)showAd:(AppodealShowStyle)style rootViewController:(UIViewController *)rootViewController;
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal showAd:AppodealAdTypeInterstitial forPlacement:@"PLACEMENT" rootViewController:UIViewController]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.showAd(AppodealShowStyle.Interstitial, forPlacement: String!, rootViewController: UIViewController!) @endcode
  *
  *  @param style              AppodealAdTypeInterstitial, AppodealAdTypeSkippableVideo, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
@@ -571,38 +281,76 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (BOOL)showAd:(AppodealShowStyle)style forPlacement:(NSString *)placement rootViewController:(UIViewController *)rootViewController;
 
 /*!
- *  @brief Start cache ad for type if autocache disabled
- *  @brief Ad will not be show after load
+ @discussion Checker for ad is ready and can be shown by current placement
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
+ *  @code [Appodeal canShowAd:AppodealShowStyleInterstitial forPlacement:MY_PLACEMENT]; @endcode
+ *
+ *  @discussion Swift
+ *  @code Appodeal.canShowAd(AppodealShowStyle.Interstitial, forPlacement:MY_PLACEMENT) @endcode
+ *
+ *  @param style              AppodealShowStyleInterstitial, AppodealShowStyleRewardedVideo, AppodealShowStyleBannerBottom, AppodealShowStyleBannerTop, AppodealShowStyleNnonSkippableVideo
+ *  @param placement          String placement name from dashboard
+ *
+ *  @return YES if possible to show or NO if not
+ */
++ (BOOL)canShowAd:(AppodealShowStyle)style forPlacement:(NSString *)placement;
+
+/*!
+ *  @discussion Return reward object currencyName as NSString, and amount as NSUInteger
+ */
++ (id<APDReward>)rewardForPlacement:(NSString *)placement;
+
+/*!
+ *  @discussion Start caching an ad for type; if autocache is disabled,
+ *  start loading for default placement
+ *  @discussion Ad will not be shown after loading
+ *
+ *  @discussion Objective-C
  *  @code [Appodeal cacheAd:AppodealAdTypeInterstitial]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.cacheAd(AppodealAdType.Interstitial) @endcode
  *
- *  @param type AppodealAdTypeInterstitial, AppodealAdTypeSkippableVideo, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
+ *  @param type AppodealAdTypeInterstitial, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
  */
 + (void)cacheAd:(AppodealAdType)type;
 
 /*!
- *  @brief Hide banner if it on screen
+ *  @discussion Start caching ad for type if autocache is disabled
+ *  start load for default placement
+ *  @discussion Ad will not be shown after load
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
+ *  @code [Appodeal cacheAd:AppodealAdTypeInterstitial forPlacement: @"YOUR_PLACEMENT"]; @endcode
+ *
+ *  @discussion Swift
+ *  @code Appodeal.cacheAd(AppodealAdType.Interstitial, for: "YOUR_PLACEMENT") @endcode
+ *
+ *  @param type AppodealAdTypeInterstitial, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
+ *  @param placement String placement that you configure in Appodeal dashboard
+ */
++ (void)cacheAd:(AppodealAdType)type forPlacement:(NSString *)placement;
+
+/*!
+ *  @discussion Hide banner if on screen
+ *
+ *  @discussion Objective-C
  *  @code [Appodeal hideBanner]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.hideBanner() @endcode
  *
  */
 + (void)hideBanner;
 
 /*!
- *  @brief Enable debug mode
+ *  @discussion Enable debug mode
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setDebugEnabled:YES]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setDebugEnabled(true) @endcode
  *
  *  @param debugEnabled Bolean flag
@@ -610,96 +358,109 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setDebugEnabled:(BOOL)debugEnabled;
 
 /*!
- *  @brief Enable testing mode.
- *  @brief In this mode your will get test ad with <b>eCPM = 0$</b>
- *  @brief Use method before initializtion!
+ *  @discussion Enable testing mode.
+ *  @discussion In this mode you will get a test ad with <b>eCPM = 0$</b>
+ *  @discussion Use method before initialization!
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setTestingEnabled:YES]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setTestingEnabled(true) @endcode
  *
  *  @param testingEnabled Bolean flag
  */
 + (void)setTestingEnabled:(BOOL)testingEnabled;
 
+
 /*!
- *  @brief Reset UUID for tracking/targeting ad
- *  @brief Use method before initializtion!
+ *  @discussion return current UUID for tracking/targeting ad
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
+ *  @code [Appodeal getUUID]; @endcode
+ *
+ *  @discussion Swift
+ *  @code Appodeal.getUUID() @endcode
+ *
+ */
++ (NSString *)getUUID;
+
+/*!
+ *  @discussion Reset UUID for tracking/targeting ad
+ *  @discussion Use method before initialization!
+ *
+ *  @discussion Objective-C
  *  @code [Appodeal resetUUID]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.resetUUID() @endcode
  *
  */
 + (void)resetUUID NS_UNAVAILABLE;
 
 /*!
- *  Get current sdk version
+ *  Get current SDK version
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal getVersion]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.getVersion() @endcode
  *
- *  @return Current sdk version
+ *  @return Current SDK version
  */
 + (NSString *)getVersion;
 
 /*!
- *  @brief Check that ad is ready to show
+ *  @discussion Check that ad is ready to show
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal isReadyForShowWithStyle:AppodealShowStyleInterstitial]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.isReadyForShowWithStyle(AppodealShowStyle.Interstitial) @endcode
  *
- *  @param showStyle AppodealShowStyleInterstitial, AppodealShowStyleSkippableVideo, AppodealShowStyleVideoOrInterstitial, AppodealShowStyleBannerTop, AppodealShowStyleBannerBottom, AppodealShowStyleRewardedVideo, AppodealShowStyleNonSkippableVideo
+ *  @param showStyle AppodealShowStyleInterstitial, AppodealShowStyleVideoOrInterstitial, AppodealShowStyleBannerTop, AppodealShowStyleBannerBottom, AppodealShowStyleRewardedVideo, AppodealShowStyleNonSkippableVideo
  *
  *  @return YES if ready or NO if not
  */
 + (BOOL)isReadyForShowWithStyle:(AppodealShowStyle)showStyle;
 
 /*!
- *  @brief You can set custom rule by usage this method.
+ *  @discussion You can set custom rule by using this method.
  *  Configure rules for segments in <b>Appodeal Dashboard</b>.
- *  @discussion For example, you want to use segment, when user complete 20 or more levels
- *  You create rule in dashboard with name "completedLevels" of type Int,
- *  operator GreaterThanOrEqualTo and value 10, now you implement folowing code:
+ *  @discussion For example, you want to create a segment of users who complete 20 or more levels
+ *  You create a rule in the dashboard with name "completedLevels" of type Int,
+ *  operator GreaterThanOrEqualTo and value 10, and then you implement the following code:
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code
-    NSDictionary * customRule = {@"completedLevels" : CURRENT_NUMBER_OF_COMPLETED_LEVELS};
-    [[APDSdk sharedSdk] setCustomRule: customRule];
+        NSDictionary * customRule = {@"completedLevels" : CURRENT_NUMBER_OF_COMPLETED_LEVELS};
+        [[APDSdk sharedSdk] setCustomRule: customRule];
  *  @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code
-    let customRule = ["completedLevels" : CURRENT_NUMBER_OF_COMPLETED_LEVELS]
-    APDSdk .sharedSdk().setCustomRule(customRule)
+        let customRule = ["completedLevels" : CURRENT_NUMBER_OF_COMPLETED_LEVELS]
+        APDSdk .sharedSdk().setCustomRule(customRule)
  *  @endcode
  *
  *  Call this method any time you want, segments change dynamically
  *
  *  @discussion And then CURRENT_NUMBER_OF_COMPLETED_LEVELS become 10 or greater
- *  You segments settings become available
+ *  Your segments settings become available
  *
- *  @param customRule NSDictionary instance with keys that similar to  keys that you tune in Appodeal Dashboard's Segment settings block and values of similar types
+ *  @param customRule NSDictionary instance with keys that are similar to keys that you turn on in Appodeal Dashboard's Segment settings block and values of similar types
  */
 + (void)setCustomRule:(NSDictionary *)customRule;
 
 /*!
- *  @brief -
+ *  @discussion -
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal confirmUsage:AppodealAdTypeInterstitial]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.confirmUsage(AppodealAdType.Interstitial) @endcode
  *
  *  @param adTypes AppodealAdTypeInterstitial, AppodealAdTypeSkippableVideo, AppodealAdTypeBanner, AppodealAdTypeNativeAd, AppodealAdTypeRewardedVideo, AppodealAdTypeMREC, AppodealAdTypeNonSkippableVideo
@@ -707,61 +468,125 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)confirmUsage:(AppodealAdType)adTypes;
 
 /*!
- *  @brief Autoresized banner suport. Default set to YES;
+ *  @discussion Autoresized banner support. Default set to YES;
  *  Call this method before caching banners!
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setSmartBannersEnabled:YES]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setSmartBannersEnabled(true) @endcode
  *
- *  @param smartBannerEnabled If YES banner will resize it depend of screen size, If NO banner has fixed size (320x50 on iPhone and 728x90 on iPad)
+ *  @param smartBannerEnabled If YES, the banner will resize depending on screen size. If NO, the banner has a fixed size (320x50 on iPhone and 728x90 on iPad)
  */
 + (void)setSmartBannersEnabled:(BOOL)smartBannerEnabled;
 
 /*!
- *  @brief Banner background visibility setter. Default set to NO.
+ *  @discussion Banner background visibility setter. Default set to NO.
  *  Call this method before caching banners!
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setBannerBackgroundVisible:YES]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setBannerBackgroundVisible(true) @endcode
  *
- *  @param bannerBackgroundVisible If YES banner will have background, if NO banner background will be transparent
+ *  @param bannerBackgroundVisible If YES,  the banner will have a background. If NO, the banner background will be transparent
  */
 + (void)setBannerBackgroundVisible:(BOOL)bannerBackgroundVisible;
 
 /*!
- *  @brief Banner animation setter. Default set to YES
+ *  @discussion Banner animation setter. Default set to YES
  *  Call this method before caching banners!
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setBannerAnimationEnabled:YES]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setBannerAnimationEnabled(true) @endcode
  *
- *  @param bannerAnimationEnabled If YES banner will refresh with animation (UIViewAnimationOptionTransitionCrossDissolve), if NO will refresh without animation;
+ *  @param bannerAnimationEnabled If YES, the banner will refresh with animation (UIViewAnimationOptionTransitionCrossDissolve). If NO, the banner will refresh without animation;
  */
 + (void)setBannerAnimationEnabled:(BOOL)bannerAnimationEnabled;
+
+/*!
+ *  @discussion Start loading native ads of count that
+ *  you specified. If Appodeal SDK already contains ads,
+ *  this method clears all cached ads before loading new ads.
+ *  We recommend calling this method once.
+ *  When you grab ready ads, the ad queue starts to replenish automatically
+ *
+ *
+ *  @discussion Objective-C
+ *  @code [Appodeal loadNaitveAd:APDNativeAdTypeAuto capacity:4]; @endcode
+ *
+ *  @discussion Swift
+ *  @code Appodeal.loadNaitveAd(APDNativeAdTypeAuto, capacity: 4) @endcode
+ *
+ *  @param type Type of native ad. Identified in APDNativeAdType enum;
+ *  @param capacity Desired count of stored in cache native ads. Maximum value is 11;
+ */
++ (void)loadNaitveAd:(APDNativeAdType)type capacity:(NSInteger)capacity;
+
+/*!
+ *  @discussion Get current available ads
+ *  @param count - Desired count of native ads. Real returned array count can be less that this parameter
+ */
++ (NSArray *)getNativeAdsOfCount:(NSInteger)count;
+
+/*!
+ *  @discussion Get current available ads count
+ */
++ (NSInteger)availableNativeAdsCount;
+
+/*!
+ *  @discussion disable user data for adNetwork name
+ *  @param networkName - adNetwork name as NSString @"NETWORK_NAME"
+ */
++ (void)disableUserData:(NSString *)networkName;
+/*!
+ *  @discussion Enable memory monitoring for ad type. If current memory consumption is higher than required, all cachied ad objects will be released
+ *  @warning loaded ad will return and not be shown
+ *
+ *  @param percentage Minimum percent of RAM free is from 1 to 100. If NSNotFound memory monitor is inactive
+ *  @param type Type of ad to use
+ */
++ (void)setMinimumFreeMemoryPercentage:(NSUInteger)percentage
+                             forAdType:(AppodealAdType)type __attribute__((deprecated("Use -setMinimumFreeMemoryPercentage:observeSystemWarnings:forAdType: instead")));
+
+/*!
+ *  @discussion Enable memory monitoring for ad type. If current memory consumption is higher than required, all cachied ad objects will be released
+ *  @warning loaded ad will return and not be shown
+ *
+ *  @param percentage Minimum percent of RAM free is from 1 to 100. If NSNotFound memory monitor is inactive
+ *  @param observeSystemWarnings Enabled observation of system memory warnings
+ *  @param type Type of ad to use
+ */
++ (void)setMinimumFreeMemoryPercentage:(NSUInteger)percentage
+                 observeSystemWarnings:(BOOL)observeSystemWarnings
+                             forAdType:(AppodealAdType)type;
+
+/*!
+ *  @discussion Enable COPPA setting flag. By defualt this setting is false
+ *
+ *  @param childDirectedTreatment Boolean flag inficates that app for kids.
+ */
++ (void)setChildDirectedTreatment:(BOOL)childDirectedTreatment;
 
 @end
 
 /*!
- *  Set user metada for right ad targeting
+ *  Set user metadata for relevant ad targeting
  */
 @interface Appodeal (UserMetadata)
 
 /*!
- *  @brief User id setter
+ *  @discussion User ID setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserId:@"USER_ID"]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserId("USER_ID") @endcode
  *
  *  @param userId Set userId as string
@@ -769,12 +594,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserId:(NSString *)userId;
 
 /*!
- *  @brief User email setter
+ *  @discussion User email setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserEmail:@"USER_EMAIL"]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserEmail("USER_EMAIL") @endcode
  *
  *  @param email Set userEmail as string
@@ -782,12 +607,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserEmail:(NSString *)email;
 
 /*!
- *  @brief User birthday setter
+ *  @discussion User birthday setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserBirthday:[NSDate date]]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserBirthday(Date() as Date!) @endcode
  *
  *  @param birthday Set userBirthday as NSDate
@@ -795,12 +620,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserBirthday:(NSDate *)birthday;
 
 /*!
- *  @brief User age setter
+ *  @discussion User age setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserAge:25]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserAge(25) @endcode
  *
  *  @param age Set age as integer value
@@ -808,12 +633,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserAge:(NSUInteger)age;
 
 /*!
- *  @brief User gender setter
+ *  @discussion User gender setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserGender:AppodealUserGenderMale]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserGender(AppodealUserGender.male) @endcode
  *
  *  @param gender AppodealUserGenderOther, AppodealUserGenderMale, AppodealUserGenderFemale
@@ -821,12 +646,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserGender:(AppodealUserGender)gender;
 
 /*!
- *  @brief User occupdation setter
+ *  @discussion User occupation setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserOccupation:AppodealUserOccupationWork]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserOccupation(AppodealUserOccupation.work) @endcode
  *
  *  @param occupation AppodealUserOccupationOther, AppodealUserOccupationWork, AppodealUserOccupationSchool, AppodealUserOccupationUniversity
@@ -834,12 +659,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserOccupation:(AppodealUserOccupation)occupation;
 
 /*!
- *  @brief User relationship setter
+ *  @discussion User relationship setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserRelationship:AppodealUserRelationshipMarried]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserRelationship(AppodealUserRelationship.married) @endcode
  *
  *  @param relationship AppodealUserRelationshipOther, AppodealUserRelationshipSingle, AppodealUserRelationshipDating, AppodealUserRelationshipEngaged, AppodealUserRelationshipMarried, AppodealUserRelationshipSearching
@@ -847,12 +672,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserRelationship:(AppodealUserRelationship)relationship;
 
 /*!
- *  @brief User smoking attitude setter
+ *  @discussion User smoking attitude setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserSmokingAttitude:AppodealUserSmokingAttitudeNeutral]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserSmokingAttitude(AppodealUserSmokingAttitude.neutral) @endcode
  *
  *  @param smokingAttitude AppodealUserSmokingAttitudeNegative, AppodealUserSmokingAttitudeNeutral, AppodealUserSmokingAttitudePositive
@@ -860,12 +685,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserSmokingAttitude:(AppodealUserSmokingAttitude)smokingAttitude;
 
 /*!
- *  @brief User alcohol attitude
+ *  @discussion User alcohol attitude setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserAlcoholAttitude:AppodealUserAlcoholAttitudeNeutral]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserAlcoholAttitude(AppodealUserAlcoholAttitude.neutral) @endcode
  *
  *  @param alcoholAttitude AppodealUserAlcoholAttitudeNegative, AppodealUserAlcoholAttitudeNeutral, AppodealUserAlcoholAttitudePositive
@@ -873,12 +698,12 @@ typedef NS_ENUM(NSUInteger, AppodealUserAlcoholAttitude) {
 + (void)setUserAlcoholAttitude:(AppodealUserAlcoholAttitude)alcoholAttitude;
 
 /*!
- *  @brief User interests setter
+ *  @discussion User interests setter
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [Appodeal setUserInterests:@"USER_INTERESTS"]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code Appodeal.setUserInterests("USER_INTERESTS") @endcode
  *
  *  @param interests Set user interests as string

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/AppodealBannerView.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/AppodealBannerView.h
@@ -2,7 +2,9 @@
 //  AppodealBannerView.h
 //  Appodeal
 //
-//  Copyright © 2016 Appodeal, Inc. All rights reserved.
+//  AppodealSDK version 2.1.4-Release
+//
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -20,81 +22,88 @@
 @optional
 
 /**
- *  Method called when banner did load firstly, after refresh this method not call
+ *  Method called when banner loads first, after refresh this method not call
  *
- *  @param bannerView Nonnul, ready to show banner
+ *  @param bannerView Non-null, ready to show banner
  */
 - (void)bannerViewDidLoadAd:(APDBannerView *)bannerView;
 
 /**
  *  Method called in case that banner mediation failed
  *
- *  @param bannerView Nonnul failed banner view
- *  @param error      Error occured while mediation
+ *  @param bannerView Non-null failed banner view
+ *  @param error      Error occurred during mediation
  */
 - (void)bannerView:(APDBannerView *)bannerView didFailToLoadAdWithError:(NSError *)error;
 
 /**
- *  Method called when user tap on banner
+ *  Method called when user taps on banner
  *
- *  @param bannerView Nonnul banner view
+ *  @param bannerView Non-null banner view
  */
 - (void)bannerViewDidInteract:(APDBannerView *)bannerView;
 
-/**
- *  Method called after banner view reload content automatically
+/*!
+ *  Method called after any banner was shown or refreshed
  *
- *  @param bannerView Nonnul banner view
+ *  @param bannerView On screen banner view
  */
-- (void)bannerViewDidRefresh:(APDBannerView *)bannerView;
+- (void)bannerViewDidShow:(APDBannerView *)bannerView;
+
+/**
+ *  Method called after banner view reloaded content automatically
+ *
+ *  @param bannerView Non-null banner view
+ */
+- (void)bannerViewDidRefresh:(APDBannerView *)bannerView __attribute__((deprecated("Use -bannerViewDidShow: instead")));
 
 @end
 
 /*!
  *  Alias on APDBannerView.
- *  Need only for backward compatibility with Appodeal sdk version 0.10.8 and lower
- *  @warning If your integrate Appodeal at first time, we highly recomeded to use APDBannerView
+ *  Needed only for backward compatibility with Appodeal SDK version 0.10.8 and lower
+ *  @warning If you integrate Appodeal for the first time, we highly recommend using APDBannerView
  */
 @interface AppodealBannerView : APDBannerView
 
 /**
- *  Getter of banner availability
+ *  Gets banner availability
  */
 @property (assign, nonatomic, readonly, getter=isReady) BOOL ready;
 
 /**
- *  Set delegate to recive callbacks declared in AppodealBannerViewDelegate protocol
+ *  Set delegate to receive callbacks declared in AppodealBannerViewDelegate protocol
  *
  *  @param delegate Nullable delegate
  */
 - (void)setDelegate:(id<AppodealBannerViewDelegate>)delegate;
 
 /**
- *  Getter of object that you set by -setDelegate:
+ *  Gets object that you set by -setDelegate:
  *
  *  @return Nullable belegate
  */
 - (id<AppodealBannerViewDelegate>)delegate;
 
 /**
- *  @brief Initializer
+ *  Initializer
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [[AppodealBannerView alloc] initWithSize:kAPDAdSize320x50 rootViewController:self]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code AppodealBannerView.init(size: kAPDAdSize320x50, rootViewController: self) @endcode
  *
  *
  *  @param size               Appodeal valid size
- *  @param rootViewController Nonnul view controller
+ *  @param rootViewController Non-null view controller
  *
  *  @return Instance of Appodeal banner view class
  */
 - (instancetype)initWithSize:(CGSize)size rootViewController:(UIViewController *)rootViewController;
 
 /**
- *  Start banner mediaition
+ *  Start banner mediation
  */
 - (void)loadAd;
 
@@ -104,16 +113,16 @@
 @interface AppodealMRECView : APDMRECView
 
 /**
- *  Set delegate to recive callbacks declared in AppodealBannerViewDelegate protocol
+ *  Set delegate to receive callbacks declared in AppodealBannerViewDelegate protocol
  *
  *  @param delegate Nullable delegate
  */
 - (void)setDelegate:(id<AppodealBannerViewDelegate>)delegate;
 
 /**
- *  Getter of object that you set by -setDelegate:
+ *  Gets object that you set by -setDelegate:
  *
- *  @return Nullable belegate
+ *  @return Nullable delegate
  */
 - (id<AppodealBannerViewDelegate>)delegate;
 
@@ -121,13 +130,13 @@
  *  Initializer
  *
  *
- *  @brief Objective-C
+ *  @discussion Objective-C
  *  @code [[AppodealMRECView alloc] initWithRootViewController:self]; @endcode
  *
- *  @brief Swift
+ *  @discussion Swift
  *  @code AppodealMRECView.init(rootViewController: self) @endcode
  *
- *  @param rootViewController Nonnul view controller
+ *  @param rootViewController Non-null view controller
  *
  *  @return Instance of Appodeal mrec view class of size 300 x 250
  */

--- a/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/AppodealRequestDelegateProtocol.h
+++ b/appodeal/ios/src/main/bro-gen/Appodeal.framework/Headers/AppodealRequestDelegateProtocol.h
@@ -1,0 +1,67 @@
+//
+//  AppodealRequestDelegateProtocol.h
+//  Appodeal
+//
+//  Created by Stas Kochkin on 05/07/2017.
+//  Copyright © 2017 Appodeal, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Appodeal/APDDefines.h>
+
+@class APDBannerView;
+@class APDInterstitialAd;
+@class APDRewardedVideo;
+
+@protocol AppodealRequestDelegate <NSObject>
+
+- (void)mediationDidStartForAdType:(AppodealAdType)adType;
+- (void)willStartAdRequestForAdNetwork:(NSString *)adNetwork adType:(AppodealAdType)adType;
+- (void)didReceiveAdResponseFromAdNetwork:(NSString *)adNetwork adType:(AppodealAdType)adType wasFilled:(BOOL)filled;
+- (void)didFinishMediationForAdType:(AppodealAdType)adType hasFilledAd:(BOOL)filled;
+- (void)didDetectImpressionForAdNetwork:(NSString *)adNetwork adType:(AppodealAdType)adType;
+- (void)didDetectClickForAdNetwork:(NSString *)adNetwork adType:(AppodealAdType)adType;
+
+@end
+
+
+@protocol APDBannerViewRequestDelegate <NSObject>
+
+@optional
+
+- (void)bannerViewDidStartMediation:(APDBannerView *)bannerView;
+- (void)bannerView:(APDBannerView *)bannerView willSendRequestToAdNetwork:(NSString *)adNetwork;
+- (void)bannerView:(APDBannerView *)bannerView didRecieveResponseFromAdNetwork:(NSString *)adNetwork wasFilled:(BOOL)filled;
+- (void)bannerView:(APDBannerView *)bannerView didFinishMediationAdWasFilled:(BOOL)filled;
+- (void)bannerView:(APDBannerView *)bannerView logImpressionForAdNetwork:(NSString *)adNetwork;
+- (void)bannerView:(APDBannerView *)bannerView logClickForAdNetwork:(NSString *)adNetwork;
+
+@end
+
+
+@protocol APDInterstitalAdRequestDelegate <NSObject>
+
+@optional
+
+- (void)interstitialDidStartMediation:(APDInterstitialAd *)interstitial;
+- (void)interstitial:(APDInterstitialAd *)interstitial willSendRequestToAdNetwork:(NSString *)adNetwork;
+- (void)interstitial:(APDInterstitialAd *)interstitial didRecieveResponseFromAdNetwork:(NSString *)adNetwork wasFilled:(BOOL)filled;
+- (void)interstitial:(APDInterstitialAd *)interstitial didFinishMediationAdWasFilled:(BOOL)filled;
+- (void)interstitial:(APDInterstitialAd *)interstitial logImpressionForAdNetwork:(NSString *)adNetwork;
+- (void)interstitial:(APDInterstitialAd *)interstitial logClickForAdNetwork:(NSString *)adNetwork;
+
+@end
+
+
+@protocol APDRewardedVideoRequestDelegate <NSObject>
+
+@optional
+
+- (void)rewardedVideoDidStartMediation:(APDRewardedVideo *)rewardedVideo;
+- (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo willSendRequestToAdNetwork:(NSString *)adNetwork;
+- (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo didRecieveResponseFromAdNetwork:(NSString *)adNetwork wasFilled:(BOOL)filled;
+- (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo didFinishMediationAdWasFilled:(BOOL)filled;
+- (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo logImpressionForAdNetwork:(NSString *)adNetwork;
+- (void)rewardedVideo:(APDRewardedVideo *)rewardedVideo logClickForAdNetwork:(NSString *)adNetwork;
+
+@end

--- a/appodeal/ios/src/main/bro-gen/appodeal.yaml
+++ b/appodeal/ios/src/main/bro-gen/appodeal.yaml
@@ -6,7 +6,9 @@ headers: [Appodeal.h]
 typedefs: {}
 
 enums:
-    AppodealAdType: {bits: true}
+    APDLogLevel: {}
+    APDNativeAdType: {}
+    AppodealAdType: {}
     AppodealShowStyle: {}
     AppodealUserGender: {}
     AppodealUserOccupation: {}
@@ -17,10 +19,18 @@ enums:
 classes:
     Appodeal:
         methods:
+            '+cacheAd:.*':
+                name: cacheAd
+            '+canShowAd:.*':
+                name: canShowAd
             '+confirmUsage:':
                 name: confirmUsage
+            '+disableNetworkForAdType:.*':
+                name: disableNetworkForAdType
             '+initializeWithApiKey:.*':
                 name: initialize
+            '+loadNaitveAd:.*':
+                name: loadNativeAd
             '+showAd:rootViewController:':
                 name: showAd
                 return_type: boolean
@@ -50,6 +60,8 @@ classes:
                 name: setAutocache
             '+setFramework:':
                 exclude: true
+            '+setMinimumFreeMemoryPercentage:.*':
+                name: setMinimumFreeMemoryPercentage
 
 protocols:
     AppodealBannerDelegate: # DONE
@@ -70,6 +82,15 @@ protocols:
     AppodealNonSkippableVideoDelegate: {} # DONE
 
     AppodealSkippableVideoDelegate: {} # DONE
+
+    AppodealNativeAdDelegate: {} # DONE
+
+    AppodealRequestDelegate:
+        methods:
+            '.+':
+                trim_after_first_colon: true
+
+    APDReward: {}
 
 functions:
     'AppodealAvailableUnitSizes':

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDLogLevel.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDLogLevel.java
@@ -37,34 +37,33 @@ import org.robovm.apple.storekit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
-    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/APDLogLevel/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Off(0L),
+    Error(1L),
+    Warning(3L),
+    Info(7L),
+    Debug(15L),
+    Verbose(31L);
+    /*</values>*/
 
-    /*<ptr>*/
-    /*</ptr>*/
     /*<bind>*/
     /*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<properties>*/
-    
-    /*</properties>*/
-    /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
-    /*</methods>*/
-    /*<adapter>*/
-    /*</adapter>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/APDLogLevel/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/APDLogLevel/*</name>*/ valueOf(long n) {
+        for (/*<name>*/APDLogLevel/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/APDLogLevel/*</name>*/.class.getName());
+    }
 }

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDNativeAdType.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDNativeAdType.java
@@ -37,34 +37,30 @@ import org.robovm.apple.storekit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
-    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedUIntMarshaler.class)/*</annotations>*/
+public enum /*<name>*/APDNativeAdType/*</name>*/ implements ValuedEnum {
+    /*<values>*/
+    Auto(0L),
+    Video(1L),
+    NoVideo(2L);
+    /*</values>*/
 
-    /*<ptr>*/
-    /*</ptr>*/
     /*<bind>*/
     /*</bind>*/
     /*<constants>*//*</constants>*/
-    /*<properties>*/
-    
-    /*</properties>*/
-    /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
-    /*</methods>*/
-    /*<adapter>*/
-    /*</adapter>*/
+    /*<methods>*//*</methods>*/
+
+    private final long n;
+
+    private /*<name>*/APDNativeAdType/*</name>*/(long n) { this.n = n; }
+    public long value() { return n; }
+    public static /*<name>*/APDNativeAdType/*</name>*/ valueOf(long n) {
+        for (/*<name>*/APDNativeAdType/*</name>*/ v : values()) {
+            if (v.n == n) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("No constant with value " + n + " found in " 
+            + /*<name>*/APDNativeAdType/*</name>*/.class.getName());
+    }
 }

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDReward.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDReward.java
@@ -38,7 +38,7 @@ import org.robovm.apple.storekit.*;
 
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/APDReward/*</name>*/ 
     /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
 
     /*<ptr>*/
@@ -47,23 +47,13 @@ import org.robovm.apple.storekit.*;
     /*</bind>*/
     /*<constants>*//*</constants>*/
     /*<properties>*/
-    
+    @Property(selector = "currencyName")
+    String getCurrencyName();
+    @Property(selector = "amount")
+    @MachineSizedUInt long getAmount();
     /*</properties>*/
     /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
+    
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDRewardAdapter.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/APDRewardAdapter.java
@@ -35,36 +35,26 @@ import org.robovm.apple.storekit.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
-    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/APDRewardAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements APDReward/*</implements>*/ {
 
     /*<ptr>*/
     /*</ptr>*/
     /*<bind>*/
     /*</bind>*/
     /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
     /*<properties>*/
-    
+    @NotImplemented("currencyName")
+    public String getCurrencyName() { return null; }
+    @NotImplemented("amount")
+    public @MachineSizedUInt long getAmount() { return 0; }
     /*</properties>*/
+    /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
+    
     /*</methods>*/
-    /*<adapter>*/
-    /*</adapter>*/
 }

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/Appodeal.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/Appodeal.java
@@ -55,12 +55,24 @@ import org.robovm.apple.storekit.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
+    @Method(selector = "disableNetworkForAdType:name:")
+    public static native void disableNetworkForAdType(AppodealAdType adType, String networkName);
+    @Method(selector = "disableLocationPermissionCheck")
+    public static native void disableLocationPermissionCheck();
     @Method(selector = "setLocationTracking:")
     public static native void setLocationTracking(boolean enabled);
     @Method(selector = "setAutocache:types:")
     public static native void setAutocache(boolean autocache, AppodealAdType types);
+    @Method(selector = "isAutocacheEnabled:")
+    public static native boolean isAutocacheEnabled(AppodealAdType types);
     @Method(selector = "initializeWithApiKey:types:")
     public static native void initialize(String apiKey, AppodealAdType types);
+    @Method(selector = "isInitalized")
+    public static native boolean isInitalized();
+    @Method(selector = "setLogLevel:")
+    public static native void setLogLevel(APDLogLevel logLevel);
+    @Method(selector = "setPluginVersion:")
+    public static native void setPluginVersion(String pluginVersion);
     @Method(selector = "setInterstitialDelegate:")
     public static native void setInterstitialDelegate(AppodealInterstitialDelegate interstitialDelegate);
     @Method(selector = "setBannerDelegate:")
@@ -71,18 +83,36 @@ import org.robovm.apple.storekit.*;
     public static native void setRewardedVideoDelegate(AppodealRewardedVideoDelegate rewardedVideoDelegate);
     @Method(selector = "setNonSkippableVideoDelegate:")
     public static native void setNonSkippableVideoDelegate(AppodealNonSkippableVideoDelegate nonSkippableVideoDelegate);
+    @Method(selector = "setNativeAdDelegate:")
+    public static native void setNativeAdDelegate(AppodealNativeAdDelegate nativeAdDelegate);
+    @Method(selector = "setRequestDelegate:")
+    public static native void setRequestDelegate(AppodealRequestDelegate requestDelegate);
     @Method(selector = "banner")
     public static native UIView banner();
+    @Method(selector = "showAd:rootViewController:")
+    public static native boolean showAd(AppodealShowStyle style, UIViewController rootViewController);
+    @Method(selector = "showAd:forPlacement:rootViewController:")
+    public static native boolean showAd(AppodealShowStyle style, String placement, UIViewController rootViewController);
+    @Method(selector = "canShowAd:forPlacement:")
+    public static native boolean canShowAd(AppodealShowStyle style, String placement);
+    @Method(selector = "rewardForPlacement:")
+    public static native APDReward rewardForPlacement(String placement);
     @Method(selector = "cacheAd:")
     public static native void cacheAd(AppodealAdType type);
+    @Method(selector = "cacheAd:forPlacement:")
+    public static native void cacheAd(AppodealAdType type, String placement);
     @Method(selector = "hideBanner")
     public static native void hideBanner();
     @Method(selector = "setDebugEnabled:")
     public static native void setDebugEnabled(boolean debugEnabled);
     @Method(selector = "setTestingEnabled:")
     public static native void setTestingEnabled(boolean testingEnabled);
+    @Method(selector = "getUUID")
+    public static native String getUUID();
     @Method(selector = "getVersion")
     public static native String getVersion();
+    @Method(selector = "isReadyForShowWithStyle:")
+    public static native boolean isReadyForShow(AppodealShowStyle showStyle);
     @Method(selector = "setCustomRule:")
     public static native void setCustomRule(NSDictionary<?, ?> customRule);
     @Method(selector = "confirmUsage:")
@@ -93,6 +123,20 @@ import org.robovm.apple.storekit.*;
     public static native void setBannerBackgroundVisible(boolean bannerBackgroundVisible);
     @Method(selector = "setBannerAnimationEnabled:")
     public static native void setBannerAnimationEnabled(boolean bannerAnimationEnabled);
+    @Method(selector = "loadNaitveAd:capacity:")
+    public static native void loadNativeAd(APDNativeAdType type, @MachineSizedSInt long capacity);
+    @Method(selector = "getNativeAdsOfCount:")
+    public static native NSArray<?> getNativeAdsOfCount(@MachineSizedSInt long count);
+    @Method(selector = "availableNativeAdsCount")
+    public static native @MachineSizedSInt long availableNativeAdsCount();
+    @Method(selector = "disableUserData:")
+    public static native void disableUserData(String networkName);
+    @Method(selector = "setMinimumFreeMemoryPercentage:forAdType:")
+    public static native void setMinimumFreeMemoryPercentage(@MachineSizedUInt long percentage, AppodealAdType type);
+    @Method(selector = "setMinimumFreeMemoryPercentage:observeSystemWarnings:forAdType:")
+    public static native void setMinimumFreeMemoryPercentage(@MachineSizedUInt long percentage, boolean observeSystemWarnings, AppodealAdType type);
+    @Method(selector = "setChildDirectedTreatment:")
+    public static native void setChildDirectedTreatment(boolean childDirectedTreatment);
     @Method(selector = "setUserId:")
     public static native void setUserId(String userId);
     @Method(selector = "setUserEmail:")
@@ -114,16 +158,4 @@ import org.robovm.apple.storekit.*;
     @Method(selector = "setUserInterests:")
     public static native void setUserInterests(String interests);
     /*</methods>*/
-
-    //TODO make it generated by bro-gen
-    @Method(selector = "showAd:rootViewController:")
-    public static native boolean showAd(AppodealShowStyle style, UIViewController rootViewController);
-
-    //TODO make it generated by bro-gen
-    @Method(selector = "showAd:forPlacement:rootViewController:")
-    public static native boolean showAd(AppodealShowStyle style, String placement, UIViewController rootViewController);
-
-    //TODO make it generated by bro-gen
-    @Method(selector = "isReadyForShowWithStyle:")
-    public static native boolean isReadyForShow(AppodealShowStyle style);
 }

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealBannerDelegate.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealBannerDelegate.java
@@ -52,6 +52,8 @@ import org.robovm.apple.storekit.*;
     /*<methods>*/
     @Method(selector = "bannerDidLoadAdIsPrecache:")
     void bannerDidLoadAd(boolean precache);
+    @Method(selector = "bannerDidLoadAd")
+    void bannerDidLoadAd();
     @Method(selector = "bannerDidRefresh")
     void bannerDidRefresh();
     @Method(selector = "bannerDidFailToLoadAd")

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealBannerDelegateAdapter.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealBannerDelegateAdapter.java
@@ -54,6 +54,8 @@ import org.robovm.apple.storekit.*;
     /*<methods>*/
     @NotImplemented("bannerDidLoadAdIsPrecache:")
     public void bannerDidLoadAd(boolean precache) {}
+    @NotImplemented("bannerDidLoadAd")
+    public void bannerDidLoadAd() {}
     @NotImplemented("bannerDidRefresh")
     public void bannerDidRefresh() {}
     @NotImplemented("bannerDidFailToLoadAd")

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealInterstitialDelegate.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealInterstitialDelegate.java
@@ -50,10 +50,14 @@ import org.robovm.apple.storekit.*;
     
     /*</properties>*/
     /*<methods>*/
+    @Method(selector = "interstitialDidLoadAd")
+    void interstitialDidLoadAd();
     @Method(selector = "interstitialDidLoadAdisPrecache:")
     void interstitialDidLoadAd(boolean precache);
     @Method(selector = "interstitialDidFailToLoadAd")
     void interstitialDidFailToLoadAd();
+    @Method(selector = "interstitialDidFailToPresent")
+    void interstitialDidFailToPresent();
     @Method(selector = "interstitialWillPresent")
     void interstitialWillPresent();
     @Method(selector = "interstitialDidDismiss")

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealInterstitialDelegateAdapter.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealInterstitialDelegateAdapter.java
@@ -52,10 +52,14 @@ import org.robovm.apple.storekit.*;
     /*</properties>*/
     /*<members>*//*</members>*/
     /*<methods>*/
+    @NotImplemented("interstitialDidLoadAd")
+    public void interstitialDidLoadAd() {}
     @NotImplemented("interstitialDidLoadAdisPrecache:")
     public void interstitialDidLoadAd(boolean precache) {}
     @NotImplemented("interstitialDidFailToLoadAd")
     public void interstitialDidFailToLoadAd() {}
+    @NotImplemented("interstitialDidFailToPresent")
+    public void interstitialDidFailToPresent() {}
     @NotImplemented("interstitialWillPresent")
     public void interstitialWillPresent() {}
     @NotImplemented("interstitialDidDismiss")

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealNativeAdDelegate.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealNativeAdDelegate.java
@@ -38,7 +38,7 @@ import org.robovm.apple.storekit.*;
 
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNativeAdDelegate/*</name>*/ 
     /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
 
     /*<ptr>*/
@@ -50,20 +50,10 @@ import org.robovm.apple.storekit.*;
     
     /*</properties>*/
     /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
+    @Method(selector = "didLoadNativeAds:")
+    void didLoadNativeAds(@MachineSizedSInt long count);
+    @Method(selector = "didFailToLoadNativeAdsWithError:")
+    void didFailToLoadNativeAdsWithError(NSError error);
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealNativeAdDelegateAdapter.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealNativeAdDelegateAdapter.java
@@ -35,36 +35,26 @@ import org.robovm.apple.storekit.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
-    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/AppodealNativeAdDelegateAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements AppodealNativeAdDelegate/*</implements>*/ {
 
     /*<ptr>*/
     /*</ptr>*/
     /*<bind>*/
     /*</bind>*/
     /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
     /*<properties>*/
     
     /*</properties>*/
+    /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
+    @NotImplemented("didLoadNativeAds:")
+    public void didLoadNativeAds(@MachineSizedSInt long count) {}
+    @NotImplemented("didFailToLoadNativeAdsWithError:")
+    public void didFailToLoadNativeAdsWithError(NSError error) {}
     /*</methods>*/
-    /*<adapter>*/
-    /*</adapter>*/
 }

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealNonSkippableVideoDelegateAdapter.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealNonSkippableVideoDelegateAdapter.java
@@ -58,6 +58,8 @@ import org.robovm.apple.storekit.*;
     public void nonSkippableVideoDidFailToLoadAd() {}
     @NotImplemented("nonSkippableVideoDidPresent")
     public void nonSkippableVideoDidPresent() {}
+    @NotImplemented("nonSkippableVideoDidFailToPresent")
+    public void nonSkippableVideoDidFailToPresent() {}
     @NotImplemented("nonSkippableVideoWillDismiss")
     public void nonSkippableVideoWillDismiss() {}
     @NotImplemented("nonSkippableVideoDidFinish")

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRequestDelegate.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRequestDelegate.java
@@ -38,7 +38,7 @@ import org.robovm.apple.storekit.*;
 
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
+/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealRequestDelegate/*</name>*/ 
     /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
 
     /*<ptr>*/
@@ -50,20 +50,18 @@ import org.robovm.apple.storekit.*;
     
     /*</properties>*/
     /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
+    @Method(selector = "mediationDidStartForAdType:")
+    void mediationDidStartForAdType(AppodealAdType adType);
+    @Method(selector = "willStartAdRequestForAdNetwork:adType:")
+    void willStartAdRequestForAdNetwork(String adNetwork, AppodealAdType adType);
+    @Method(selector = "didReceiveAdResponseFromAdNetwork:adType:wasFilled:")
+    void didReceiveAdResponseFromAdNetwork(String adNetwork, AppodealAdType adType, boolean filled);
+    @Method(selector = "didFinishMediationForAdType:hasFilledAd:")
+    void didFinishMediationForAdType(AppodealAdType adType, boolean filled);
+    @Method(selector = "didDetectImpressionForAdNetwork:adType:")
+    void didDetectImpressionForAdNetwork(String adNetwork, AppodealAdType adType);
+    @Method(selector = "didDetectClickForAdNetwork:adType:")
+    void didDetectClickForAdNetwork(String adNetwork, AppodealAdType adType);
     /*</methods>*/
     /*<adapter>*/
     /*</adapter>*/

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRequestDelegateAdapter.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRequestDelegateAdapter.java
@@ -35,36 +35,34 @@ import org.robovm.apple.storekit.*;
 /*</imports>*/
 
 /*<javadoc>*/
-
 /*</javadoc>*/
 /*<annotations>*//*</annotations>*/
-/*<visibility>*/public/*</visibility>*/ interface /*<name>*/AppodealNonSkippableVideoDelegate/*</name>*/ 
-    /*<implements>*/extends NSObjectProtocol/*</implements>*/ {
+/*<visibility>*/public/*</visibility>*/ class /*<name>*/AppodealRequestDelegateAdapter/*</name>*/ 
+    extends /*<extends>*/NSObject/*</extends>*/ 
+    /*<implements>*/implements AppodealRequestDelegate/*</implements>*/ {
 
     /*<ptr>*/
     /*</ptr>*/
     /*<bind>*/
     /*</bind>*/
     /*<constants>*//*</constants>*/
+    /*<constructors>*//*</constructors>*/
     /*<properties>*/
     
     /*</properties>*/
+    /*<members>*//*</members>*/
     /*<methods>*/
-    @Method(selector = "nonSkippableVideoDidLoadAd")
-    void nonSkippableVideoDidLoadAd();
-    @Method(selector = "nonSkippableVideoDidFailToLoadAd")
-    void nonSkippableVideoDidFailToLoadAd();
-    @Method(selector = "nonSkippableVideoDidPresent")
-    void nonSkippableVideoDidPresent();
-    @Method(selector = "nonSkippableVideoDidFailToPresent")
-    void nonSkippableVideoDidFailToPresent();
-    @Method(selector = "nonSkippableVideoWillDismiss")
-    void nonSkippableVideoWillDismiss();
-    @Method(selector = "nonSkippableVideoDidFinish")
-    void nonSkippableVideoDidFinish();
-    @Method(selector = "nonSkippableVideoDidClick")
-    void nonSkippableVideoDidClick();
+    @NotImplemented("mediationDidStartForAdType:")
+    public void mediationDidStartForAdType(AppodealAdType adType) {}
+    @NotImplemented("willStartAdRequestForAdNetwork:adType:")
+    public void willStartAdRequestForAdNetwork(String adNetwork, AppodealAdType adType) {}
+    @NotImplemented("didReceiveAdResponseFromAdNetwork:adType:wasFilled:")
+    public void didReceiveAdResponseFromAdNetwork(String adNetwork, AppodealAdType adType, boolean filled) {}
+    @NotImplemented("didFinishMediationForAdType:hasFilledAd:")
+    public void didFinishMediationForAdType(AppodealAdType adType, boolean filled) {}
+    @NotImplemented("didDetectImpressionForAdNetwork:adType:")
+    public void didDetectImpressionForAdNetwork(String adNetwork, AppodealAdType adType) {}
+    @NotImplemented("didDetectClickForAdNetwork:adType:")
+    public void didDetectClickForAdNetwork(String adNetwork, AppodealAdType adType) {}
     /*</methods>*/
-    /*<adapter>*/
-    /*</adapter>*/
 }

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRewardedVideoDelegate.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRewardedVideoDelegate.java
@@ -54,6 +54,8 @@ import org.robovm.apple.storekit.*;
     void rewardedVideoDidLoadAd();
     @Method(selector = "rewardedVideoDidFailToLoadAd")
     void rewardedVideoDidFailToLoadAd();
+    @Method(selector = "rewardedVideoDidFailToPresent")
+    void rewardedVideoDidFailToPresent();
     @Method(selector = "rewardedVideoDidPresent")
     void rewardedVideoDidPresent();
     @Method(selector = "rewardedVideoWillDismiss")

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRewardedVideoDelegateAdapter.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealRewardedVideoDelegateAdapter.java
@@ -56,6 +56,8 @@ import org.robovm.apple.storekit.*;
     public void rewardedVideoDidLoadAd() {}
     @NotImplemented("rewardedVideoDidFailToLoadAd")
     public void rewardedVideoDidFailToLoadAd() {}
+    @NotImplemented("rewardedVideoDidFailToPresent")
+    public void rewardedVideoDidFailToPresent() {}
     @NotImplemented("rewardedVideoDidPresent")
     public void rewardedVideoDidPresent() {}
     @NotImplemented("rewardedVideoWillDismiss")

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealShowStyle.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealShowStyle.java
@@ -37,15 +37,17 @@ import org.robovm.apple.storekit.*;
 /*<javadoc>*/
 
 /*</javadoc>*/
-/*<annotations>*/@Marshaler(ValuedEnum.AsMachineSizedSIntMarshaler.class)/*</annotations>*/
-public enum /*<name>*/AppodealShowStyle/*</name>*/ implements ValuedEnum {
+/*<annotations>*/@Marshaler(Bits.AsMachineSizedIntMarshaler.class)/*</annotations>*/
+public final class /*<name>*/AppodealShowStyle/*</name>*/ extends Bits</*<name>*/AppodealShowStyle/*</name>*/> {
     /*<values>*/
-    Interstitial(1L),
-    SkippableVideo(2L),
-    BannerTop(4L),
-    BannerBottom(5L),
-    RewardedVideo(6L),
-    NonSkippableVideo(7L);
+    public static final AppodealShowStyle None = new AppodealShowStyle(0L);
+    public static final AppodealShowStyle Interstitial = new AppodealShowStyle(1L);
+    public static final AppodealShowStyle SkippableVideo = new AppodealShowStyle(1L);
+    public static final AppodealShowStyle VideoOrInterstitial = new AppodealShowStyle(1L);
+    public static final AppodealShowStyle BannerTop = new AppodealShowStyle(4L);
+    public static final AppodealShowStyle BannerBottom = new AppodealShowStyle(8L);
+    public static final AppodealShowStyle RewardedVideo = new AppodealShowStyle(16L);
+    public static final AppodealShowStyle NonSkippableVideo = new AppodealShowStyle(32L);
     /*</values>*/
 
     /*<bind>*/
@@ -53,17 +55,17 @@ public enum /*<name>*/AppodealShowStyle/*</name>*/ implements ValuedEnum {
     /*<constants>*//*</constants>*/
     /*<methods>*//*</methods>*/
 
-    private final long n;
+    private static final /*<name>*/AppodealShowStyle/*</name>*/[] values = _values(/*<name>*/AppodealShowStyle/*</name>*/.class);
 
-    private /*<name>*/AppodealShowStyle/*</name>*/(long n) { this.n = n; }
-    public long value() { return n; }
-    public static /*<name>*/AppodealShowStyle/*</name>*/ valueOf(long n) {
-        for (/*<name>*/AppodealShowStyle/*</name>*/ v : values()) {
-            if (v.n == n) {
-                return v;
-            }
-        }
-        throw new IllegalArgumentException("No constant with value " + n + " found in " 
-            + /*<name>*/AppodealShowStyle/*</name>*/.class.getName());
+    public /*<name>*/AppodealShowStyle/*</name>*/(long value) { super(value); }
+    private /*<name>*/AppodealShowStyle/*</name>*/(long value, long mask) { super(value, mask); }
+    protected /*<name>*/AppodealShowStyle/*</name>*/ wrap(long value, long mask) {
+        return new /*<name>*/AppodealShowStyle/*</name>*/(value, mask);
+    }
+    protected /*<name>*/AppodealShowStyle/*</name>*/[] _values() {
+        return values;
+    }
+    public static /*<name>*/AppodealShowStyle/*</name>*/[] values() {
+        return values.clone();
     }
 }

--- a/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealUnitSize.java
+++ b/appodeal/ios/src/main/java/org/robovm/pods/appodeal/AppodealUnitSize.java
@@ -59,9 +59,9 @@ import org.robovm.apple.storekit.*;
     @Bridge(symbol="AppodealAvailableUnitSizes", optional=true)
     public static native NSArray<?> availableUnitSizes();
     @Bridge(symbol="AppodealIsUnitSizeSupported", optional=true)
-    public static native int isUnitSizeSupported();
+    public static native boolean isUnitSizeSupported(@ByVal CGSize size, NSArray<?> supportedSizes);
     @Bridge(symbol="AppodealIsUnitSizeAvailable", optional=true)
-    public static native int isUnitSizeAvailable();
+    public static native boolean isUnitSizeAvailable(@ByVal CGSize size);
     @Bridge(symbol="AppodealNearestUnitSizeForSize", optional=true)
     public static native @ByVal CGSize nearestUnitSizeForSize(@ByVal CGSize size);
     /*</methods>*/

--- a/appodeal/ios/src/main/robopods/META-INF/robovm/ios/robovm.xml
+++ b/appodeal/ios/src/main/robopods/META-INF/robovm/ios/robovm.xml
@@ -8,17 +8,20 @@
     <frameworks>        
         <framework>Appodeal</framework>
 
+        <framework>AdSupport</framework>
         <framework>AudioToolbox</framework>
         <framework>AVFoundation</framework>
         <framework>CFNetwork</framework>
-        <framework>CoreFoundation</framework>
         <framework>CoreGraphics</framework>
         <framework>CoreImage</framework>
         <framework>CoreLocation</framework>
         <framework>CoreMedia</framework>
         <framework>CoreMotion</framework>
-        <framework>EventKit</framework>
+        <framework>CoreTelephony</framework>
         <framework>EventKitUI</framework>
+        <framework>GLKit</framework>
+        <framework>ImageIO</framework>
+        <framework>JavaScriptCore</framework>
         <framework>MediaPlayer</framework>
         <framework>MessageUI</framework>
         <framework>MobileCoreServices</framework>
@@ -30,15 +33,7 @@
         <framework>Twitter</framework>
         <framework>UIKit</framework>
         <framework>WebKit</framework>
-        <framework>JavaScriptCore</framework>
-        <framework>CoreBluetooth</framework>
-        <framework>GLKit</framework>
-        <framework>SafariServices</framework>
     </frameworks>
-    <weakFrameworks>
-        <framework>AdSupport</framework>
-        <framework>CoreTelephony</framework>
-    </weakFrameworks>
     <forceLinkClasses>
         <pattern>org.robovm.pods.appodeal.Appodeal</pattern>
     </forceLinkClasses>


### PR DESCRIPTION
Previous bindings were made a long time ago for Appodeal 1.x. They are incompatible with the current Appodeal 2.x (which is used by some of the users by mistake).
This pull request migrate the bindings to 2.x. (2.1.4), which is the right version to support ios 11.

Probably it will break build for some users of the robopod. But I guess it is OK, because they are using SNAPSHOT version of robopods.